### PR TITLE
Fix Pool Address Prediction API & Database and data model enhancements 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN npm prune --omit=dev
 # Final stage for app image
 FROM base
 
-ARG CQA_VERSION=2.0.2
+ARG CQA_VERSION=2.0.3
 ADD https://github.com/clones-ai/clones-quality-agent/releases/download/v${CQA_VERSION}/clones-quality-agent-linux-x64 ./clones-quality-agent
 RUN chmod +x clones-quality-agent
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,7 +4,7 @@ FROM node:lts
 ENV NODE_ENV="development"
 
 WORKDIR /app
-ARG CQA_VERSION=2.0.2
+ARG CQA_VERSION=2.0.3
 ADD https://github.com/clones-ai/clones-quality-agent/releases/download/v${CQA_VERSION}/clones-quality-agent-linux-x64 ./clones-quality-agent
 RUN chmod +x clones-quality-agent
 

--- a/src/api/forge/factories.test.ts
+++ b/src/api/forge/factories.test.ts
@@ -318,7 +318,7 @@ describe('Forge Factories API', () => {
     })
   })
 
-  describe('GET /pools/predict-address', () => {
+  describe('POST /pools/predict-address', () => {
     it('should predict a pool address', async () => {
       mockFactoryService.predictPoolAddress.mockResolvedValue({
         predicted: '0xPredictedAddress',

--- a/src/api/forge/factories.test.ts
+++ b/src/api/forge/factories.test.ts
@@ -318,7 +318,7 @@ describe('Forge Factories API', () => {
     })
   })
 
-  describe('GET /pools/predict', () => {
+  describe('GET /pools/predict-address', () => {
     it('should predict a pool address', async () => {
       mockFactoryService.predictPoolAddress.mockResolvedValue({
         predicted: '0xPredictedAddress',
@@ -329,7 +329,8 @@ describe('Forge Factories API', () => {
       const token = 'WETH'
 
       const response = await supertest(app)
-        .get(`/api/v1/forge/factories/pools/predict?creator=${creator}&token=${token}`)
+        .post('/api/v1/forge/factories/pools/predict-address')
+        .send({ creator, token })
         .expect(200)
 
       expect(mockFactoryService.predictPoolAddress).toHaveBeenCalledWith(

--- a/src/api/forge/factories.ts
+++ b/src/api/forge/factories.ts
@@ -585,23 +585,26 @@ router.post(
 
 /**
  * @swagger
- * /forge/factories/pools/predict:
- *   get:
+ * /forge/factories/pools/predict-address:
+ *   post:
  *     summary: Predict reward pool address
  *     tags: [Factories]
- *     parameters:
- *       - in: query
- *         name: creator
- *         required: true
- *         schema:
- *           type: string
- *           format: hex
- *       - in: query
- *         name: token
- *         required: true
- *         schema:
- *           type: string
- *           format: hex
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - creator
+ *               - token
+ *             properties:
+ *               creator:
+ *                 type: string
+ *                 format: hex
+ *               token:
+ *                 type: string
+ *                 format: hex
  *     responses:
  *       '200':
  *         description: Pool prediction data
@@ -610,11 +613,11 @@ router.post(
  *       '500':
  *         description: Internal server error
  */
-router.get(
-  '/pools/predict',
-  validateQuery(predictPoolSchema),
+router.post(
+  '/pools/predict-address',
+  validateBody(predictPoolSchema),
   errorHandlerAsync(async (req: Request, res: Response) => {
-    const { creator, token } = req.query as unknown as PredictPoolQuery
+    const { creator, token } = req.body as PredictPoolQuery
 
     try {
       const factoryService = createFactoryService()

--- a/src/api/forge/submissions.ts
+++ b/src/api/forge/submissions.ts
@@ -148,6 +148,7 @@ router.get(
         reward: submission.reward,
         maxReward: submission.maxReward,
         clampedScore: submission.clampedScore,
+        claimAuthorization: submission.claimAuthorization,
         cqaModel: submission.cqaModel,
         cqaEvaluationModel: submission.cqaEvaluationModel,
         createdAt: submission.createdAt,

--- a/src/models/DemonstrationSubmission.ts
+++ b/src/models/DemonstrationSubmission.ts
@@ -53,6 +53,21 @@ export const demonstrationSubmissionSchema = new mongoose.Schema<DBDemonstration
       },
       required: false
     },
+    claimAuthorization: {
+      type: {
+        // Smart contract parameters
+        account: String,
+        cumulativeAmount: String,
+        signature: String,
+        // Additional context
+        publisherUsed: String,
+        poolAddress: String,
+        tokenAddress: String,
+        alreadyClaimed: Number,
+        newClaimableAmount: Number
+      },
+      required: false
+    },
     cqaModel: { type: String, required: false },
     cqaEvaluationModel: { type: String, required: false }
   },

--- a/src/services/forge/processing.ts
+++ b/src/services/forge/processing.ts
@@ -170,7 +170,6 @@ export async function processNextInQueue() {
       let maxReward
       const clampedScore = Math.max(0, Math.min(100, gradeResult.score))
       let onChainReward: OnChainReward | undefined
-      let claimAuthorization: any
       let retries = 3
 
       // Get factory details if factoryId exists
@@ -351,7 +350,7 @@ export async function processNextInQueue() {
           const tokenAddress = getTokenContractAddress(factory.token.symbol)
 
           // Generate claim authorization signature - it will handle smart contract reads internally
-          claimAuthorization = await claimAuthService.generateClaimAuthorization(
+          const claimAuthorization = await claimAuthService.generateClaimAuthorization(
             factory.poolAddress,
             submission.address,
             reward // Just pass the current reward, service will calculate cumulative

--- a/src/services/forge/processing.ts
+++ b/src/services/forge/processing.ts
@@ -379,6 +379,7 @@ export async function processNextInQueue() {
             `${submission.grade_result.reasoning}`
           submission.grade_result.reasoning = reasoningMessage
           submission.onChainReward = onChainReward
+          submission.claimAuthorization = claimAuthorization
 
           // Save updated claim authorization data
           await submission.save()

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -1,5 +1,5 @@
 import type { Types } from 'mongoose'
-import type { ForgeSubmissionProcessingStatus } from './index.ts'
+import type { ForgeSubmissionProcessingStatus, OnChainReward } from './index.ts'
 
 export interface DBDemonstrationSubmission {
   _id?: string
@@ -32,13 +32,16 @@ export interface DBDemonstrationSubmission {
   reward?: number
   maxReward?: number
   clampedScore?: number
-  onChainReward?: {
-    tokenAddress?: string
-    poolAddress?: string
-    amount?: number
-    taskId?: string
-    txHash?: string
-    timestamp?: number
+  onChainReward?: OnChainReward
+  claimAuthorization?: {
+    account: string
+    cumulativeAmount: string
+    signature: string
+    publisherUsed: string
+    poolAddress: string
+    tokenAddress: string
+    alreadyClaimed: number
+    newClaimableAmount: number
   }
   cqaModel?: string
   cqaEvaluationModel?: string


### PR DESCRIPTION
This pull request introduces two main updates: it changes the pool address prediction API from a GET endpoint with query parameters to a POST endpoint with a JSON body, and it adds support for storing and returning claim authorization data in demonstration submissions. Additionally, it updates the version of the `clones-quality-agent` used in Docker images.

**API changes:**

* Changed the pool address prediction endpoint from `GET /pools/predict` (with query parameters) to `POST /pools/predict-address` (with a JSON body), updated the corresponding OpenAPI/Swagger documentation, and adjusted tests accordingly. [[1]](diffhunk://#diff-104fd975a95c870aa8893f4603fecfca62fbaf2de6d2b8c5f691f2daa9dcaa9dL588-R605) [[2]](diffhunk://#diff-104fd975a95c870aa8893f4603fecfca62fbaf2de6d2b8c5f691f2daa9dcaa9dL613-R620) [[3]](diffhunk://#diff-554833677609fdb995a64970036a9f7d7715ff115860f97d2e6abf00d6820f56L321-R321) [[4]](diffhunk://#diff-554833677609fdb995a64970036a9f7d7715ff115860f97d2e6abf00d6820f56L332-R333)

**Database and data model enhancements:**

* Added a new `claimAuthorization` field to the `DemonstrationSubmission` schema, updated the TypeScript types, and ensured this data is saved and returned in API responses. [[1]](diffhunk://#diff-983f09a7564e575bf2419c50db4c2478207cb357a0cf7e81302d4c47c07ff19eR56-R70) [[2]](diffhunk://#diff-e90f57f0f6228a3a97d2799dbca7eb501315764bd3f94552d9bf738436336263L35-R44) [[3]](diffhunk://#diff-406813c787aa45f6dc8e908d7352d9a7983a20fa082a23764accf76818602b18R382) [[4]](diffhunk://#diff-4147e965dead3e5e88e544d1ea606291216cb6ae6a2822b7ea43d5459f6b218dR151) [[5]](diffhunk://#diff-e90f57f0f6228a3a97d2799dbca7eb501315764bd3f94552d9bf738436336263L2-R2)

**Dependency updates:**

* Updated the `clones-quality-agent` version from `2.0.2` to `2.0.3` in both `Dockerfile` and `Dockerfile.dev`. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L36-R36) [[2]](diffhunk://#diff-86930c95a19b82f7e64a962a0053d44e855824813019b3698eae4917a90cdcacL7-R7)