### PR TITLE
CQA improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN npm prune --omit=dev
 # Final stage for app image
 FROM base
 
-ARG CQA_VERSION=2.0.9
+ARG CQA_VERSION=2.0.11
 ADD https://github.com/clones-ai/clones-quality-agent/releases/download/v${CQA_VERSION}/clones-quality-agent-linux-x64 ./clones-quality-agent
 RUN chmod +x clones-quality-agent
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,7 +4,7 @@ FROM node:lts
 ENV NODE_ENV="development"
 
 WORKDIR /app
-ARG CQA_VERSION=2.0.9
+ARG CQA_VERSION=2.0.11
 ADD https://github.com/clones-ai/clones-quality-agent/releases/download/v${CQA_VERSION}/clones-quality-agent-linux-x64 ./clones-quality-agent
 RUN chmod +x clones-quality-agent
 

--- a/src/services/demo-storage/index.ts
+++ b/src/services/demo-storage/index.ts
@@ -1,49 +1,49 @@
 import { ObjectStorageService } from '../storage/index.ts'
-import { 
-  DemoFiles, 
-  DemoIntegrity, 
-  FileIntegrity, 
+import {
+  DemoFiles,
+  DemoIntegrity,
+  FileIntegrity,
   DemoManifest,
-  DatasetManifest 
+  DatasetManifest
 } from './types.ts'
-import { 
-  generateDemoHash, 
-  calculateFileHash, 
-  calculateOverallHash, 
-  getDemoStoragePath 
+import {
+  generateDemoHash,
+  calculateFileHash,
+  calculateOverallHash,
+  getDemoStoragePath
 } from './hash.ts'
 
 export class DemoStorageService {
-  constructor(private objectStorage: ObjectStorageService) {}
+  constructor(private objectStorage: ObjectStorageService) { }
 
   /**
    * Store a complete demonstration with integrity verification
    */
   async storeDemo(
-    submissionId: string, 
-    userAddress: string, 
+    submissionId: string,
+    userAddress: string,
     files: DemoFiles,
     metadata?: Partial<DemoManifest>
   ): Promise<string> {
     const timestamp = Date.now()
     const demoHash = generateDemoHash(submissionId, userAddress, timestamp)
-    
+
     console.log(`[DemoStorage] Storing demo ${demoHash} for submission ${submissionId}`)
-    
+
     const fileIntegrities: FileIntegrity[] = []
-    
+
     // Store each file with integrity tracking
     for (const [filename, buffer] of Object.entries(files)) {
       const filePath = getDemoStoragePath(demoHash, filename)
       const fileHash = calculateFileHash(buffer)
-      
+
       console.log(`[DemoStorage] Storing ${filename} at ${filePath} (${buffer.length} bytes, hash: ${fileHash.substring(0, 16)}...)`)
-      
+
       await this.objectStorage.saveItem({
         name: filePath,
         file: buffer
       })
-      
+
       fileIntegrities.push({
         filename,
         sha256: fileHash,
@@ -51,13 +51,14 @@ export class DemoStorageService {
         lastModified: new Date().toISOString()
       })
     }
-    
+
     // Generate overall integrity hash
     const fileHashes = fileIntegrities.map(f => f.sha256)
     const overallHash = calculateOverallHash(fileHashes)
-    
+
     // Create integrity manifest
     const integrity: DemoIntegrity = {
+      schema_version: { major: 1, minor: 0, patch: 0 },
       demoHash,
       submissionId,
       userAddress: userAddress.toLowerCase(),
@@ -65,33 +66,34 @@ export class DemoStorageService {
       files: fileIntegrities,
       overallHash
     }
-    
+
     // Store integrity manifest
     const integrityPath = getDemoStoragePath(demoHash, 'checksums.json')
     await this.objectStorage.saveItem({
       name: integrityPath,
       file: Buffer.from(JSON.stringify(integrity, null, 2))
     })
-    
+
     // Store demo manifest if metadata provided
     if (metadata) {
       const demoManifest: DemoManifest = {
+        schema_version: { major: 1, minor: 0, patch: 0 },
         demonstration_id: demoHash,
         user_address: userAddress.toLowerCase(),
         submission_id: submissionId,
         created_at: new Date().toISOString(),
         ...metadata
       }
-      
+
       const manifestPath = getDemoStoragePath(demoHash, 'manifest.json')
       await this.objectStorage.saveItem({
         name: manifestPath,
         file: Buffer.from(JSON.stringify(demoManifest, null, 2))
       })
     }
-    
+
     console.log(`[DemoStorage] Demo ${demoHash} stored successfully with overall hash ${overallHash.substring(0, 16)}...`)
-    
+
     return demoHash
   }
 
@@ -100,7 +102,7 @@ export class DemoStorageService {
    */
   async getDemoFile(demoHash: string, filename: string): Promise<Buffer> {
     const filePath = getDemoStoragePath(demoHash, filename)
-    
+
     try {
       return await this.objectStorage.getItem({ name: filePath })
     } catch (error) {
@@ -114,7 +116,7 @@ export class DemoStorageService {
    */
   async getDemoFileStream(demoHash: string, filename: string): Promise<NodeJS.ReadableStream> {
     const filePath = getDemoStoragePath(demoHash, filename)
-    
+
     try {
       return await this.objectStorage.getItemStream({ name: filePath })
     } catch (error) {
@@ -128,27 +130,27 @@ export class DemoStorageService {
    */
   async verifyDemo(demoHash: string): Promise<{ valid: boolean; errors: string[] }> {
     const errors: string[] = []
-    
+
     try {
       // Load integrity manifest
       const integrityPath = getDemoStoragePath(demoHash, 'checksums.json')
       const integrityBuffer = await this.objectStorage.getItem({ name: integrityPath })
       const integrity: DemoIntegrity = JSON.parse(integrityBuffer.toString())
-      
+
       // Verify each file
       const actualFileHashes: string[] = []
-      
+
       for (const fileInfo of integrity.files) {
         try {
           const fileBuffer = await this.getDemoFile(demoHash, fileInfo.filename)
           const currentHash = calculateFileHash(fileBuffer)
-          
+
           if (currentHash !== fileInfo.sha256) {
             errors.push(`File ${fileInfo.filename} hash mismatch: expected ${fileInfo.sha256}, got ${currentHash}`)
           } else {
             actualFileHashes.push(currentHash)
           }
-          
+
           if (fileBuffer.length !== fileInfo.size) {
             errors.push(`File ${fileInfo.filename} size mismatch: expected ${fileInfo.size}, got ${fileBuffer.length}`)
           }
@@ -156,7 +158,7 @@ export class DemoStorageService {
           errors.push(`File ${fileInfo.filename} not accessible: ${error}`)
         }
       }
-      
+
       // Verify overall hash if all files are accessible
       if (actualFileHashes.length === integrity.files.length) {
         const currentOverallHash = calculateOverallHash(actualFileHashes)
@@ -164,13 +166,13 @@ export class DemoStorageService {
           errors.push(`Overall hash mismatch: expected ${integrity.overallHash}, got ${currentOverallHash}`)
         }
       }
-      
+
       return { valid: errors.length === 0, errors }
-      
+
     } catch (error) {
-      return { 
-        valid: false, 
-        errors: [`Failed to verify demo: ${error}`] 
+      return {
+        valid: false,
+        errors: [`Failed to verify demo: ${error}`]
       }
     }
   }
@@ -197,7 +199,7 @@ export class DemoStorageService {
     if (!integrity) {
       throw new Error(`Demo integrity not found: ${demoHash}`)
     }
-    
+
     return integrity.files.map(f => ({
       filename: f.filename,
       size: f.size,
@@ -221,6 +223,7 @@ export class DemoStorageService {
         recording: 'MP4 video file of screen recording',
         meta: 'JSON metadata about the demonstration',
         input_log: 'JSONL file with interaction events',
+        input_log_meta: 'JSON metadata about the input log',
         sft: 'JSON file with supervised fine-tuning annotations'
       },
       integrity: {
@@ -228,7 +231,7 @@ export class DemoStorageService {
         verified_at: new Date().toISOString()
       }
     }
-    
+
     await this.objectStorage.saveItem({
       name: 'datasets/computer-use-v1/manifest.json',
       file: Buffer.from(JSON.stringify(manifest, null, 2))

--- a/src/services/demo-storage/types.ts
+++ b/src/services/demo-storage/types.ts
@@ -15,11 +15,35 @@ export interface DemoIntegrity {
   overallHash: string
 }
 
+/**
+ * Metadata for the input log file.
+ * 
+ * - `timestamp_type`: Indicates how timestamps in the input log are represented.
+ * - `'relative'`: Timestamps are measured relative to the start of the recording(e.g., seconds or milliseconds since recording began).
+ * - `'absolute'`: Timestamps are absolute, typically in Unix epoch time or ISO 8601 format.
+ * - `created_at`: The date and time when the input log was created, as an ISO 8601 string(e.g., "2023-06-01T12:34:56Z").
+ */
 export interface InputLogMeta {
+  /**
+   * Version of the schema used for this input log.
+   */
   schema_version: SchemaVersion
+  /**
+   * Format of the input log file. Currently only 'jsonl' is supported.
+   */
   format: 'jsonl'
+  /**
+   * Number of events recorded in the input log.
+   */
   event_count: number
+  /**
+   * Indicates whether timestamps in the input log are 'relative' or 'absolute'.
+   */
   timestamp_type: 'relative' | 'absolute'
+  /**
+   * ISO 8601 string representing when the input log was created.
+   * Example: "2023-06-01T12:34:56Z"
+   */
   created_at: string
 }
 
@@ -31,10 +55,20 @@ export interface DemoFiles {
   'sft.json': Buffer
 }
 
+/**
+ * Represents the semantic versioning contract for demo-related types.
+ * 
+ * Follows the Semantic Versioning specification (https://semver.org/):
+ * - `major`: Incremented for breaking changes that are not backward compatible.
+ * - `minor`: Incremented for new features that are backward compatible.
+ * - `patch`: Incremented for bug fixes and backward compatible changes.
+ * 
+ * This interface is used to track the schema version of various demo-related data structures.
+ */
 export interface SchemaVersion {
-  major: number   // Breaking changes
-  minor: number   // New features, backward compatible
-  patch: number   // Bug fixes
+  major: number
+  minor: number
+  patch: number
 }
 
 export interface DemoManifest {

--- a/src/services/demo-storage/types.ts
+++ b/src/services/demo-storage/types.ts
@@ -6,6 +6,7 @@ export interface FileIntegrity {
 }
 
 export interface DemoIntegrity {
+  schema_version: SchemaVersion
   demoHash: string
   submissionId: string
   userAddress: string
@@ -14,14 +15,30 @@ export interface DemoIntegrity {
   overallHash: string
 }
 
+export interface InputLogMeta {
+  schema_version: SchemaVersion
+  format: 'jsonl'
+  event_count: number
+  timestamp_type: 'relative' | 'absolute'
+  created_at: string
+}
+
 export interface DemoFiles {
   'recording.mp4': Buffer
   'meta.json': Buffer
   'input_log.jsonl': Buffer
+  'input_log_meta.json': Buffer
   'sft.json': Buffer
 }
 
+export interface SchemaVersion {
+  major: number   // Breaking changes
+  minor: number   // New features, backward compatible
+  patch: number   // Bug fixes
+}
+
 export interface DemoManifest {
+  schema_version: SchemaVersion
   demonstration_id: string
   user_address: string
   submission_id: string
@@ -59,6 +76,7 @@ export interface DatasetManifest {
     recording: string
     meta: string
     input_log: string
+    input_log_meta: string
     sft: string
   }
   integrity: {


### PR DESCRIPTION
This pull request introduces versioning for demo-related metadata and adds support for an additional input log metadata file in the demo storage service. The main changes are the introduction of a `schema_version` field to various manifest and integrity objects, the definition of a new `InputLogMeta` type, and updates to file handling to accommodate the new metadata file.

#### Demo metadata and manifest improvements

* Added a `schema_version` field to `DemoIntegrity` and `DemoManifest` objects in `src/services/demo-storage/index.ts` and `src/services/demo-storage/types.ts`, enabling explicit versioning for stored demo metadata. [[1]](diffhunk://#diff-f8e8dbdbd794f6cc7dd1b42dd7507a1a6cb1e92ed6e54aaf30b9037bfd753ffaR61) [[2]](diffhunk://#diff-f8e8dbdbd794f6cc7dd1b42dd7507a1a6cb1e92ed6e54aaf30b9037bfd753ffaR80) [[3]](diffhunk://#diff-03c9b661c8bb26fe84efd8b9ba9d28ee8bd6ac1700833dd4b5abd415b7784fc5R9) [[4]](diffhunk://#diff-03c9b661c8bb26fe84efd8b9ba9d28ee8bd6ac1700833dd4b5abd415b7784fc5R79)
* Defined a new `SchemaVersion` interface to standardize versioning across demo-related types.

#### Input log metadata support

* Introduced a new `InputLogMeta` interface and corresponding `input_log_meta.json` file to store metadata about input logs, including event count and timestamp type. [[1]](diffhunk://#diff-03c9b661c8bb26fe84efd8b9ba9d28ee8bd6ac1700833dd4b5abd415b7784fc5R18-R41) [[2]](diffhunk://#diff-f8e8dbdbd794f6cc7dd1b42dd7507a1a6cb1e92ed6e54aaf30b9037bfd753ffaR226) [[3]](diffhunk://#diff-03c9b661c8bb26fe84efd8b9ba9d28ee8bd6ac1700833dd4b5abd415b7784fc5R79)

#### Dependency updates

* Updated the `CQA_VERSION` argument in both `Dockerfile` and `Dockerfile.dev` from `2.0.9` to `2.0.11` to use the latest version of the clones-quality-agent binary. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L36-R36) [[2]](diffhunk://#diff-86930c95a19b82f7e64a962a0053d44e855824813019b3698eae4917a90cdcacL7-R7)