### PR TITLE
Fetch cached USD price

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,3 +64,9 @@ STORAGE_BUCKET=training-gym
 # CQA Models
 CQA_MODEL=gpt-4o-mini
 CQA_EVALUATION_MODEL=gpt-4o-mini
+
+# --- Price USD API Configuration ---
+# URL for the clones-supply-api service for fetching token prices
+PRICE_USD_API_URL=http://localhost:8080
+# API key for production access to the price USD API endpoints
+PRICE_USD_API_KEY=

--- a/src/services/blockchain/index.ts
+++ b/src/services/blockchain/index.ts
@@ -23,7 +23,7 @@ class BlockchainService {
     }
   }
 
-  /** Fetch ETH price in USD from CoinGecko */
+  /** Fetch ETH price in USD from the custom Price USD API */
   static async getEthPriceInUSD(): Promise<number> {
     try {
       return await this.getTokenPriceUSD('ETH')
@@ -33,10 +33,10 @@ class BlockchainService {
     }
   }
 
-  /** Fetch token price in USD from CoinGecko */
+  /** Fetch token price in USD from the custom Price USD API */
   static async getTokenPriceUSD(tokenSymbol: string): Promise<number> {
     const supportedTokens = ['ETH', 'WETH', 'USDC', 'CLONES']
-    
+
     if (!supportedTokens.includes(tokenSymbol.toUpperCase())) {
       throw new Error(`Token ${tokenSymbol} is not supported for price fetching`)
     }
@@ -44,11 +44,11 @@ class BlockchainService {
     try {
       const apiUrl = process.env.PRICE_USD_API_URL || 'http://localhost:8080'
       const headers: Record<string, string> = {}
-      
-      if (process.env.NODE_ENV === 'production' && process.env.PRICE_USD_API_KEY) {
+
+      if (process.env.PRICE_USD_API_KEY) {
         headers['X-API-Key'] = process.env.PRICE_USD_API_KEY
       }
-      
+
       const r = await fetch(`${apiUrl}/price/${tokenSymbol.toUpperCase()}`, { headers })
 
       if (!r.ok) {

--- a/src/services/blockchain/index.ts
+++ b/src/services/blockchain/index.ts
@@ -25,48 +25,41 @@ class BlockchainService {
 
   /** Fetch ETH price in USD from CoinGecko */
   static async getEthPriceInUSD(): Promise<number> {
-    const fallback = 3000
     try {
-      const r = await fetch(
-        'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd'
-      )
-      const data = await r.json()
-      return data?.ethereum?.usd ?? fallback
+      return await this.getTokenPriceUSD('ETH')
     } catch (e) {
       console.error('Error fetching ETH price:', e)
-      return fallback
+      return 3000 // fallback
     }
   }
 
   /** Fetch token price in USD from CoinGecko */
   static async getTokenPriceUSD(tokenSymbol: string): Promise<number> {
-    const tokenMappings: { [key: string]: string } = {
-      'ETH': 'ethereum',
-      'WETH': 'ethereum',
-      'USDC': 'usd-coin',
-      'CLONES': 'clones'
-    }
-
-    const coinId = tokenMappings[tokenSymbol.toUpperCase()]
-
-    if (!coinId) {
+    const supportedTokens = ['ETH', 'WETH', 'USDC', 'CLONES']
+    
+    if (!supportedTokens.includes(tokenSymbol.toUpperCase())) {
       throw new Error(`Token ${tokenSymbol} is not supported for price fetching`)
     }
 
     try {
-      const r = await fetch(
-        `https://api.coingecko.com/api/v3/simple/price?ids=${coinId}&vs_currencies=usd`
-      )
+      const apiUrl = process.env.PRICE_USD_API_URL || 'http://localhost:8080'
+      const headers: Record<string, string> = {}
+      
+      if (process.env.NODE_ENV === 'production' && process.env.PRICE_USD_API_KEY) {
+        headers['X-API-Key'] = process.env.PRICE_USD_API_KEY
+      }
+      
+      const r = await fetch(`${apiUrl}/price/${tokenSymbol.toUpperCase()}`, { headers })
 
       if (!r.ok) {
-        throw new Error(`CoinGecko API returned status ${r.status}`)
+        throw new Error(`Price USD API returned status ${r.status}`)
       }
 
-      const data = await r.json()
-      const price = data?.[coinId]?.usd
+      const priceText = await r.text()
+      const price = parseFloat(priceText)
 
-      if (price === undefined || price === null) {
-        throw new Error(`Price not available for ${tokenSymbol}`)
+      if (isNaN(price)) {
+        throw new Error(`Invalid price format from Price USD API for ${tokenSymbol}`)
       }
 
       return price


### PR DESCRIPTION
This pull request updates how token prices in USD are fetched by switching from the CoinGecko API to a configurable internal Price USD API. It introduces new environment variables for API configuration and refactors the logic for fetching token prices, including improved error handling and API key support for production.

**Environment configuration:**

* Added `PRICE_USD_API_URL` and `PRICE_USD_API_KEY` to `.env.example` to allow configuration of the internal Price USD API endpoint and authentication.

**Token price fetching logic:**

* Refactored `BlockchainService.getTokenPriceUSD` to fetch prices from the internal Price USD API instead of CoinGecko, supporting only specific tokens (`ETH`, `WETH`, `USDC`, `CLONES`). Includes support for API key authentication in production and improved error messages.
* Updated `BlockchainService.getEthPriceInUSD` to use the new `getTokenPriceUSD` method for consistency and centralized logic.