### PR TITLE
Viralmind migration + Add objectives in tasks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN npm prune --omit=dev
 # Final stage for app image
 FROM base
 
-ARG CQA_VERSION=3.0.4
+ARG CQA_VERSION=3.0.12
 ADD https://releases.clones-ai.com/cqa/clones-quality-agent-linux-x64-package-v${CQA_VERSION}.tar.gz ./cqa-package.tar.gz
 RUN mkdir ./cqa && \
     tar -xzf cqa-package.tar.gz -C ./cqa && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,7 +4,7 @@ FROM node:lts
 ENV NODE_ENV="development"
 
 WORKDIR /app
-ARG CQA_VERSION=3.0.4
+ARG CQA_VERSION=3.0.12
 ADD https://releases.clones-ai.com/cqa/clones-quality-agent-linux-x64-package-v${CQA_VERSION}.tar.gz ./cqa-package.tar.gz
 RUN mkdir ./cqa && \
     tar -xzf cqa-package.tar.gz -C ./cqa && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,6 @@ services:
       - redis
     extra_hosts:
       - "host.docker.internal:host-gateway"
-      - "deb.debian.org:host-gateway"
 
 networks:
   default:

--- a/scripts/migrate-demonstrations.ts
+++ b/scripts/migrate-demonstrations.ts
@@ -1,0 +1,328 @@
+#!/usr/bin/env node
+
+/**
+ * Migration script to import ViralMind demonstration submissions into new DemonstrationSubmission collection
+ * 
+ * Usage: npx tsx scripts/migrate-demonstrations.ts [environment]
+ * Environment: development (default), test, production
+ */
+
+import { readFileSync } from 'fs'
+import mongoose from 'mongoose'
+import { FactoryModel } from '../src/models/Factory.ts'
+import { DemonstrationSubmission } from '../src/models/DemonstrationSubmission.ts'
+import { ForgeSubmissionProcessingStatus } from '../src/types/index.ts'
+import { generateDemoHash } from '../src/services/demo-storage/hash.ts'
+
+// Get environment from command line or default to development
+const environment = process.argv[2] || 'development'
+const validEnvironments = ['development', 'test', 'production']
+
+if (!validEnvironments.includes(environment)) {
+  console.error(`❌ Invalid environment: ${environment}`)
+  console.error(`Valid environments: ${validEnvironments.join(', ')}`)
+  process.exit(1)
+}
+
+console.log(`🚀 Running demonstration migration for environment: ${environment}`)
+
+// Path to submissions data file
+const SUBMISSIONS_PATH = '/Users/SSe/SSe/app/Clones-workspace/clones-quality-agent/data/stats_viralmind/viralmind.forge_race_submissions.json'
+
+// Owner address based on environment
+const OWNER_ADDRESS = environment === 'development'
+  ? '0x243eDd6b1F48636568476c8167CBe63C7Fe0ac8D'
+  : '0x6E60D7b7b1587863dE6D2078C020d61F65781d7e'
+
+// MongoDB connection
+const MONGODB_URI = process.env.DB_URI || 'mongodb://admin:admin@localhost:27017/dev?authSource=admin'
+
+/**
+ * Load archived factories and create pool_id mapping
+ */
+async function getPoolIdMapping(): Promise<Map<string, string>> {
+  console.log('Loading archived factories for pool_id mapping...')
+
+  const archivedFactories = await FactoryModel.find(
+    { status: 'archived' },
+    { _id: 1 }
+  ).lean()
+
+  const poolIdMap = new Map<string, string>()
+
+  archivedFactories.forEach(factory => {
+    // Extract pool_id from factory._id (format: "factory_{pool_id}")
+    const poolId = factory._id.replace('factory_', '')
+    poolIdMap.set(poolId, factory._id)
+  })
+
+  console.log(`Found ${poolIdMap.size} archived factories with pool_id mapping`)
+  return poolIdMap
+}
+
+/**
+ * Transform ViralMind submission to DemonstrationSubmission format
+ */
+function transformSubmission(submission: any, poolIdMap: Map<string, string>) {
+  const poolId = submission.meta?.quest?.pool_id
+  const taskId = submission.meta?.quest?.task_id
+
+  if (!poolId || !poolIdMap.has(poolId)) {
+    throw new Error(`Pool ID ${poolId} not found in archived factories`)
+  }
+
+  if (!taskId) {
+    throw new Error(`Task ID missing in submission ${submission._id}`)
+  }
+
+  // Generate demo hash using submission ID, address, and timestamp
+  const timestamp = submission.meta?.timestamp ? new Date(submission.meta.timestamp).getTime() : Date.now()
+  const demoHash = generateDemoHash(submission._id, OWNER_ADDRESS, timestamp)
+
+  // Create meta object with task_id properly set
+  const meta = {
+    ...submission.meta,
+    quest: {
+      ...submission.meta.quest,
+      task_id: taskId
+    },
+    schema_version: {
+      major: 1,
+      minor: 0,
+      patch: 0
+    }
+  }
+
+  // Handle dates properly - use meta.timestamp or current time
+  const createdDate = submission.createdAt
+    ? new Date(submission.createdAt)
+    : submission.meta?.timestamp
+      ? new Date(submission.meta.timestamp)
+      : new Date()
+
+  const updatedDate = submission.updatedAt
+    ? new Date(submission.updatedAt)
+    : submission.meta?.timestamp
+      ? new Date(submission.meta.timestamp)
+      : new Date()
+
+  // Validate dates
+  const validCreatedDate = isNaN(createdDate.getTime()) ? new Date() : createdDate
+  const validUpdatedDate = isNaN(updatedDate.getTime()) ? new Date() : updatedDate
+
+  return {
+    _id: submission._id,
+    address: OWNER_ADDRESS.toLowerCase(),
+    meta: meta,
+    status: ForgeSubmissionProcessingStatus.COMPLETED,
+    demoHash: demoHash,
+    fileManifest: null,
+    integrityVerified: false,
+    integrityLastCheck: null,
+    grade_result: null,
+    grading_metrics: null,
+    error: null,
+    reward: 0,
+    maxReward: 0,
+    clampedScore: null,
+    onChainReward: null,
+    claimAuthorization: null,
+    farmerReferrerAddress: null,
+    factoryReferrerAddress: null,
+    cqaModel: null,
+    createdAt: validCreatedDate,
+    updatedAt: validUpdatedDate
+  }
+}
+
+/**
+ * Load and parse submissions JSON file
+ */
+function loadSubmissions() {
+  console.log('Loading submissions data file...')
+
+  const submissionsData = JSON.parse(readFileSync(SUBMISSIONS_PATH, 'utf8'))
+  console.log(`Loaded ${submissionsData.length} submissions`)
+
+  return submissionsData
+}
+
+/**
+ * Connect to MongoDB
+ */
+async function connectToMongo() {
+  console.log(`Connecting to MongoDB: ${MONGODB_URI}`)
+  await mongoose.connect(MONGODB_URI)
+  console.log('Connected to MongoDB')
+}
+
+/**
+ * Main migration function
+ */
+async function migrate() {
+  try {
+    // Connect to database
+    await connectToMongo()
+
+    // Get pool_id mapping from archived factories
+    const poolIdMap = await getPoolIdMapping()
+
+    if (poolIdMap.size === 0) {
+      console.log('⚠️  No archived factories found. Please run factory migration first.')
+      return
+    }
+
+    // Load submissions data
+    const submissionsData = loadSubmissions()
+
+    console.log('Starting demonstration migration...')
+
+    const demonstrations: any[] = []
+    let processed = 0
+    let errors = 0
+    let skippedNoPool = 0
+    const errorStats = new Map<string, number>() // Track error types
+
+    for (const submission of submissionsData) {
+      try {
+        const poolId = submission.meta?.quest?.pool_id
+
+        // Skip submissions without valid pool_id mapping
+        if (!poolId || !poolIdMap.has(poolId)) {
+          skippedNoPool++
+          continue
+        }
+
+        const demonstration = transformSubmission(submission, poolIdMap)
+        demonstrations.push(demonstration)
+        processed++
+
+        if (processed % 100 === 0) {
+          console.log(`Processed ${processed} submissions...`)
+        }
+      } catch (error: any) {
+        const errorType = error.message.includes('Pool ID') ? 'pool_not_found' :
+          error.message.includes('Task ID') ? 'task_id_missing' :
+            'transformation_error'
+
+        errorStats.set(errorType, (errorStats.get(errorType) || 0) + 1)
+        console.error(`Error processing submission ${submission._id}:`, error.message)
+        errors++
+      }
+    }
+
+    console.log(`\nTransformation complete:`)
+    console.log(`- Total submissions: ${submissionsData.length}`)
+    console.log(`- Processed: ${processed}`)
+    console.log(`- Skipped (no pool mapping): ${skippedNoPool}`)
+    console.log(`- Errors: ${errors}`)
+
+    // Error breakdown
+    if (errorStats.size > 0) {
+      console.log(`\nError breakdown:`)
+      errorStats.forEach((count, type) => {
+        console.log(`  - ${type}: ${count}`)
+      })
+    }
+
+    console.log(`- Ready to insert: ${demonstrations.length}`)
+
+    // Debug: show first demonstration
+    if (demonstrations.length > 0) {
+      console.log('\nFirst demonstration sample:')
+      console.log(JSON.stringify(demonstrations[0], null, 2))
+
+      // Test single insert first
+      console.log('\nTesting single demonstration insert...')
+      try {
+        const testDemo = new DemonstrationSubmission(demonstrations[0])
+        await testDemo.validate()
+        console.log('✅ Validation passed for first demonstration')
+      } catch (validationError: any) {
+        console.error('❌ Validation failed:', validationError.message)
+        console.error('Validation errors:', validationError.errors)
+      }
+    }
+
+    if (demonstrations.length > 0) {
+      console.log('\nChecking for existing demonstrations...')
+
+      // Check for existing demonstrations
+      const existingIds = await DemonstrationSubmission.find(
+        { _id: { $in: demonstrations.map(d => d._id) } },
+        { _id: 1 }
+      ).lean()
+
+      if (existingIds.length > 0) {
+        console.log(`ℹ️  Found ${existingIds.length} existing demonstrations that will be skipped:`)
+        existingIds.slice(0, 5).forEach((d: any) => console.log(`  - ${d._id}`))
+        if (existingIds.length > 5) {
+          console.log(`  - ... and ${existingIds.length - 5} more`)
+        }
+      }
+
+      // Filter out existing demonstrations
+      const newDemonstrations = demonstrations.filter(d =>
+        !existingIds.some((existing: any) => existing._id === d._id)
+      )
+
+      console.log(`📊 Migration summary:`)
+      console.log(`  - Total processed: ${demonstrations.length}`)
+      console.log(`  - Already exist: ${existingIds.length}`)
+      console.log(`  - New to insert: ${newDemonstrations.length}`)
+
+      if (newDemonstrations.length === 0) {
+        console.log('\n✅ All demonstrations already exist in database. Migration complete!')
+        return
+      }
+
+      try {
+        console.log(`\nInserting ${newDemonstrations.length} demonstrations...`)
+        const result = await DemonstrationSubmission.insertMany(newDemonstrations, {
+          ordered: false // Continue on errors
+        })
+
+        console.log(`✅ Successfully inserted ${result.length} demonstrations`)
+      } catch (error: any) {
+        if (error.writeErrors && error.writeErrors.length > 0) {
+          console.log(`❌ ${error.writeErrors.length} insertion errors:`)
+          error.writeErrors.slice(0, 5).forEach((err: any, index: number) => {
+            console.log(`  ${index + 1}. Demonstration: ${err.err.op._id}`)
+            console.log(`     Error: ${err.err.errmsg}`)
+            if (err.err.errInfo && err.err.errInfo.details) {
+              console.log(`     Details: ${JSON.stringify(err.err.errInfo.details)}`)
+            }
+          })
+          const insertedCount = error.result ? error.result.insertedCount : 0
+          console.log(`✅ Successfully inserted ${insertedCount} demonstrations despite errors`)
+        } else {
+          console.log('❌ Insertion error:', error.message)
+          throw error
+        }
+      }
+    }
+
+    // Final verification
+    const finalCount = await DemonstrationSubmission.countDocuments()
+    console.log(`\n📊 Final verification: ${finalCount} demonstrations in database`)
+
+    console.log('\n🎉 Demonstration migration completed successfully!')
+
+  } catch (error) {
+    console.error('❌ Demonstration migration failed:', error)
+    process.exit(1)
+  } finally {
+    await mongoose.disconnect()
+    console.log('Disconnected from MongoDB')
+  }
+}
+
+// Run migration if this script is executed directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  migrate().catch(error => {
+    console.error('Fatal error:', error)
+    process.exit(1)
+  })
+}
+
+export { migrate }

--- a/scripts/migrate-viralmind-data.ts
+++ b/scripts/migrate-viralmind-data.ts
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+
+/**
+ * Migration script to import old viralmind data into new factory structure
+ * 
+ * Usage: npx tsx scripts/migrate-viralmind-data.ts [environment]
+ * Environment: development (default), test, production
+ */
+
+import { readFileSync } from 'fs'
+import mongoose, { Types } from 'mongoose'
+import { FactoryModel, type IFactoryDocument } from '../src/models/Factory.ts'
+import { FactoryStatus } from '../src/types/factory.ts'
+
+// Get environment from command line or default to development
+const environment = process.argv[2] || 'development'
+const validEnvironments = ['development', 'test', 'production']
+
+if (!validEnvironments.includes(environment)) {
+  console.error(`❌ Invalid environment: ${environment}`)
+  console.error(`Valid environments: ${validEnvironments.join(', ')}`)
+  process.exit(1)
+}
+
+console.log(`🚀 Running migration for environment: ${environment}`)
+
+// Paths to data files
+const TRAINING_POOLS_PATH = '/Users/SSe/SSe/app/Clones-workspace/clones-quality-agent/data/stats_viralmind/viralmind.training_pools.json'
+const FORGE_APPS_PATH = '/Users/SSe/SSe/app/Clones-workspace/clones-quality-agent/data/stats_viralmind/viralmind.forge_apps.json'
+
+// Owner address based on environment
+const OWNER_ADDRESS = environment === 'development' 
+  ? '0x243eDd6b1F48636568476c8167CBe63C7Fe0ac8D'
+  : '0x6E60D7b7b1587863dE6D2078C020d61F65781d7e'
+
+// Note: For archived factories, we don't set poolAddress or token
+
+// MongoDB connection
+const MONGODB_URI = process.env.DB_URI || 'mongodb://admin:admin@localhost:27017/dev?authSource=admin'
+
+/**
+ * Format skills: split by \n and capitalize after each newline
+ */
+function formatSkills(skillsText) {
+  if (!skillsText) return []
+
+  return skillsText
+    .split('\n')
+    .map(skill => skill.trim())
+    .filter(skill => skill.length > 0)
+    .map(skill => skill.charAt(0).toUpperCase() + skill.slice(1))
+}
+
+/**
+ * Transform training pool data to factory format
+ */
+function transformTrainingPool(pool: any, appsMap: Map<string, any[]>) {
+  const poolId = pool._id.$oid
+  const factoryId = `factory_${poolId}`
+
+  // Get associated apps for this pool
+  const poolApps = appsMap.get(poolId) || []
+
+  // Transform apps to factory app format
+  const apps = poolApps.map((app: any) => ({
+    id: app._id.$oid,
+    name: app.name,
+    domain: app.domain,
+    description: app.description || '',
+    categories: app.categories || [],
+    tasks: app.tasks.map((task: any) => ({
+      id: task._id.$oid,
+      prompt: task.prompt,
+      uploadLimit: undefined,
+      rewardLimit: undefined
+    }))
+  }))
+
+  return {
+    _id: factoryId,
+    // poolAddress and token are optional for archived factories
+    name: pool.name,
+    description: undefined,
+    ownerAddress: OWNER_ADDRESS.toLowerCase(),
+    status: FactoryStatus.archived,
+    skills: formatSkills(pool.skills),
+    totalEarned: Types.Decimal128.fromString('0'),
+    apps: apps,
+    createdAt: new Date(pool.createdAt.$date),
+    updatedAt: new Date(pool.updatedAt.$date)
+  }
+}
+
+/**
+ * Load and parse JSON files
+ */
+function loadData() {
+  console.log('Loading data files...')
+
+  const trainingPoolsData = JSON.parse(readFileSync(TRAINING_POOLS_PATH, 'utf8'))
+  const forgeAppsData = JSON.parse(readFileSync(FORGE_APPS_PATH, 'utf8'))
+
+  console.log(`Loaded ${trainingPoolsData.length} training pools`)
+  console.log(`Loaded ${forgeAppsData.length} forge apps`)
+
+  // Create map of apps by pool_id for efficient lookup
+  const appsMap = new Map()
+
+  forgeAppsData.forEach(app => {
+    const poolId = app.pool_id?.$oid
+    if (poolId) {
+      if (!appsMap.has(poolId)) {
+        appsMap.set(poolId, [])
+      }
+      appsMap.get(poolId).push(app)
+    }
+  })
+
+  console.log(`Apps mapped to ${appsMap.size} pools`)
+
+  return { trainingPoolsData, appsMap }
+}
+
+/**
+ * Connect to MongoDB
+ */
+async function connectToMongo() {
+  console.log(`Connecting to MongoDB: ${MONGODB_URI}`)
+  await mongoose.connect(MONGODB_URI)
+  console.log('Connected to MongoDB')
+}
+
+/**
+ * Main migration function
+ */
+async function migrate() {
+  try {
+    // Load data
+    const { trainingPoolsData, appsMap } = loadData()
+
+    // Connect to database
+    await connectToMongo()
+
+    console.log('Starting migration...')
+
+    const factories: Partial<IFactoryDocument>[] = []
+    let processed = 0
+    let errors = 0
+
+    for (const pool of trainingPoolsData) {
+      try {
+        const factory = transformTrainingPool(pool, appsMap)
+        factories.push(factory)
+        processed++
+
+        if (processed % 10 === 0) {
+          console.log(`Processed ${processed}/${trainingPoolsData.length} pools`)
+        }
+      } catch (error) {
+        console.error(`Error processing pool ${pool._id.$oid}:`, error.message)
+        errors++
+      }
+    }
+
+    console.log(`\nTransformation complete:`)
+    console.log(`- Processed: ${processed} pools`)
+    console.log(`- Errors: ${errors}`)
+    console.log(`- Ready to insert: ${factories.length} factories`)
+
+    // Debug: show first factory
+    if (factories.length > 0) {
+      console.log('\nFirst factory sample:')
+      console.log(JSON.stringify(factories[0], null, 2))
+    }
+
+    if (factories.length > 0) {
+      console.log('\nChecking for existing factories...')
+
+      // Check for existing factories
+      const existingIds = await FactoryModel.find(
+        { _id: { $in: factories.map(f => f._id) } },
+        { _id: 1 }
+      ).lean()
+
+      if (existingIds.length > 0) {
+        console.log(`ℹ️  Found ${existingIds.length} existing factories that will be skipped:`)
+        existingIds.slice(0, 5).forEach(f => console.log(`  - ${f._id}`))
+        if (existingIds.length > 5) {
+          console.log(`  - ... and ${existingIds.length - 5} more`)
+        }
+      }
+
+      // Filter out existing factories
+      const newFactories = factories.filter(f =>
+        !existingIds.some(existing => existing._id === f._id)
+      )
+
+      console.log(`📊 Migration summary:`)
+      console.log(`  - Total processed: ${factories.length}`)
+      console.log(`  - Already exist: ${existingIds.length}`)
+      console.log(`  - New to insert: ${newFactories.length}`)
+
+      if (newFactories.length === 0) {
+        console.log('\n✅ All factories already exist in database. Migration complete!')
+        return
+      }
+
+      try {
+        const result = await FactoryModel.insertMany(newFactories, {
+          ordered: false // Continue on errors
+        })
+
+        console.log(`✅ Successfully inserted ${result.length} factories`)
+      } catch (error: any) {
+        if (error.writeErrors && error.writeErrors.length > 0) {
+          console.log(`❌ ${error.writeErrors.length} insertion errors:`)
+          error.writeErrors.slice(0, 5).forEach((err: any, index: number) => {
+            console.log(`  ${index + 1}. Factory: ${err.err.op._id}`)
+            console.log(`     Error: ${err.err.errmsg}`)
+            if (err.err.errInfo && err.err.errInfo.details) {
+              console.log(`     Details: ${JSON.stringify(err.err.errInfo.details)}`)
+            }
+          })
+          const insertedCount = error.result ? error.result.insertedCount : 0
+          console.log(`✅ Successfully inserted ${insertedCount} factories despite errors`)
+        } else {
+          console.log('❌ Insertion error:', error.message)
+          throw error
+        }
+      }
+    }
+
+    console.log('\n🎉 Migration completed successfully!')
+
+  } catch (error) {
+    console.error('❌ Migration failed:', error)
+    process.exit(1)
+  } finally {
+    await mongoose.disconnect()
+    console.log('Disconnected from MongoDB')
+  }
+}
+
+// Run migration if this script is executed directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  migrate().catch(error => {
+    console.error('Fatal error:', error)
+    process.exit(1)
+  })
+}
+
+export { migrate }

--- a/scripts/viralmind-migration/cleanup-old-sft-files.ts
+++ b/scripts/viralmind-migration/cleanup-old-sft-files.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+/**
+ * Cleanup script for old sft.json files
+ *
+ * This script:
+ * 1. Reads all subdirectories in data/sft_files
+ * 2. Checks the creation date of each directory
+ * 3. Deletes sft.json files from directories created more than 5 minutes ago
+ * 4. Keeps sft.json files from recently created directories (< 5 min)
+ *
+ * Usage: npx tsx scripts/cleanup-old-sft-files.ts
+ */
+
+import { promises as fs } from 'fs'
+import * as path from 'path'
+
+const SFT_FILES_DIR = path.join(process.cwd(), 'data', 'sft_files')
+const MAX_AGE_MINUTES = 5
+const MAX_AGE_MS = MAX_AGE_MINUTES * 60 * 1000
+
+interface CleanupStats {
+  totalFolders: number
+  keptFiles: number
+  deletedFiles: number
+  errors: number
+}
+
+/**
+ * Clean up sft.json files from old directories
+ */
+async function cleanupOldSftFiles(): Promise<CleanupStats> {
+  const stats: CleanupStats = {
+    totalFolders: 0,
+    keptFiles: 0,
+    deletedFiles: 0,
+    errors: 0
+  }
+
+  console.log(`🧹 Cleaning up old sft.json files...`)
+  console.log(`📁 Directory: ${SFT_FILES_DIR}`)
+  console.log(`⏱️  Max age: ${MAX_AGE_MINUTES} minutes\n`)
+
+  // Check if directory exists
+  try {
+    await fs.access(SFT_FILES_DIR)
+  } catch {
+    console.log(`⚠️  Directory ${SFT_FILES_DIR} does not exist yet.`)
+    return stats
+  }
+
+  // Read all subdirectories
+  const entries = await fs.readdir(SFT_FILES_DIR, { withFileTypes: true })
+  const folders = entries.filter(entry => entry.isDirectory())
+
+  stats.totalFolders = folders.length
+  console.log(`📊 Found ${folders.length} folder(s) to analyze\n`)
+
+  for (const folder of folders) {
+    const folderPath = path.join(SFT_FILES_DIR, folder.name)
+    const sftJsonPath = path.join(folderPath, 'sft.json')
+
+    try {
+      // Check if sft.json exists
+      try {
+        await fs.access(sftJsonPath)
+      } catch {
+        // No sft.json in this folder, continue
+        continue
+      }
+
+      // Check folder age
+      const folderStats = await fs.stat(folderPath)
+      const createdAt = folderStats.birthtime
+      const now = new Date()
+      const ageMs = now.getTime() - createdAt.getTime()
+      const ageMinutes = Math.floor(ageMs / 60000)
+
+      if (ageMs < MAX_AGE_MS) {
+        // Recent folder, keep the file
+        console.log(`✅ Keeping: ${folder.name} (created ${ageMinutes} min ago)`)
+        stats.keptFiles++
+      } else {
+        // Old folder, delete the file
+        await fs.unlink(sftJsonPath)
+        console.log(`🗑️  Deleted: ${folder.name}/sft.json (created ${ageMinutes} min ago)`)
+        stats.deletedFiles++
+      }
+
+    } catch (error: any) {
+      console.error(`❌ Error processing ${folder.name}:`, error.message)
+      stats.errors++
+    }
+  }
+
+  return stats
+}
+
+/**
+ * Main function
+ */
+async function main() {
+  try {
+    const startTime = Date.now()
+
+    const stats = await cleanupOldSftFiles()
+
+    const duration = ((Date.now() - startTime) / 1000).toFixed(2)
+
+    console.log(`\n${'='.repeat(60)}`)
+    console.log(`📊 Cleanup Summary:`)
+    console.log(`   - Folders analyzed: ${stats.totalFolders}`)
+    console.log(`   - Files kept: ${stats.keptFiles}`)
+    console.log(`   - Files deleted: ${stats.deletedFiles}`)
+    console.log(`   - Errors: ${stats.errors}`)
+    console.log(`   - Duration: ${duration}s`)
+    console.log(`${'='.repeat(60)}`)
+
+    console.log(`\n✅ Cleanup completed!`)
+
+  } catch (error: any) {
+    console.error(`\n❌ Fatal error:`, error.message)
+    process.exit(1)
+  }
+}
+
+// Run script if called directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(error => {
+    console.error('Fatal error:', error)
+    process.exit(1)
+  })
+}
+
+export { cleanupOldSftFiles }

--- a/scripts/viralmind-migration/migrate-demonstrations.ts
+++ b/scripts/viralmind-migration/migrate-demonstrations.ts
@@ -2,17 +2,29 @@
 
 /**
  * Migration script to import ViralMind demonstration submissions into new DemonstrationSubmission collection
- * 
+ *
  * Usage: npx tsx scripts/migrate-demonstrations.ts [environment]
  * Environment: development (default), test, production
+ *
+ * COMPATIBILITY NOTE (task-centric model):
+ * This script remains compatible with the new Factory.tasks[] structure because:
+ * - Task IDs are preserved during factory migration (Task.id field)
+ * - This script only references task IDs from submission metadata
+ * - No factory structure modifications are performed here
+ * - The meta.quest.task_id field is passed through as-is
  */
 
+import { config } from 'dotenv'
 import { readFileSync } from 'fs'
+
+// Load environment variables from .env file
+config()
 import mongoose from 'mongoose'
-import { FactoryModel } from '../src/models/Factory.ts'
-import { DemonstrationSubmission } from '../src/models/DemonstrationSubmission.ts'
-import { ForgeSubmissionProcessingStatus } from '../src/types/index.ts'
-import { generateDemoHash } from '../src/services/demo-storage/hash.ts'
+import { FactoryModel } from '../../src/models/Factory.ts'
+import { DemonstrationSubmission } from '../../src/models/DemonstrationSubmission.ts'
+import { ForgeSubmissionProcessingStatus } from '../../src/types/index.ts'
+import { generateDemoHash } from '../../src/services/demo-storage/hash.ts'
+import { ObjectStorageService } from '../../src/services/storage/index.ts'
 
 // Get environment from command line or default to development
 const environment = process.argv[2] || 'development'
@@ -30,12 +42,100 @@ console.log(`🚀 Running demonstration migration for environment: ${environment
 const SUBMISSIONS_PATH = '/Users/SSe/SSe/app/Clones-workspace/clones-quality-agent/data/stats_viralmind/viralmind.forge_race_submissions.json'
 
 // Owner address based on environment
-const OWNER_ADDRESS = environment === 'development'
-  ? '0x243eDd6b1F48636568476c8167CBe63C7Fe0ac8D'
-  : '0x6E60D7b7b1587863dE6D2078C020d61F65781d7e'
+const OWNER_ADDRESS = '0x6E60D7b7b1587863dE6D2078C020d61F65781d7e'
 
 // MongoDB connection
 const MONGODB_URI = process.env.DB_URI || 'mongodb://admin:admin@localhost:27017/dev?authSource=admin'
+
+// ViralMind Tigris storage configuration
+const VIRAL_ACCESS_KEY = process.env.VIRAL_ACCESS_KEY
+const VIRAL_SECRET_ACCESS_KEY = process.env.VIRAL_SECRET_ACCESS_KEY
+const VIRAL_ENDPOINT = process.env.VIRAL_ENDPOINT
+const VIRAL_BUCKET = 'clones-bucket-prod'
+const VIRAL_REGION = 'auto'
+
+// Initialize ViralMind storage service
+let viralStorageService: ObjectStorageService | null = null
+
+function getViralStorageService(): ObjectStorageService {
+  if (!viralStorageService) {
+    if (!VIRAL_ACCESS_KEY || !VIRAL_SECRET_ACCESS_KEY || !VIRAL_ENDPOINT) {
+      throw new Error('ViralMind Tigris credentials not configured. Please set VIRAL_ACCESS_KEY, VIRAL_SECRET_ACCESS_KEY, and VIRAL_ENDPOINT environment variables.')
+    }
+    viralStorageService = new ObjectStorageService(
+      VIRAL_ACCESS_KEY,
+      VIRAL_SECRET_ACCESS_KEY,
+      VIRAL_ENDPOINT,
+      VIRAL_REGION,
+      VIRAL_BUCKET
+    )
+  }
+  return viralStorageService
+}
+
+/**
+ * Build fileManifest from ViralMind files array
+ * Checks file existence on ViralMind Tigris and populates size
+ */
+async function buildFileManifest(files: any[]): Promise<{
+  fileManifest: any
+  legacyStoragePaths: Record<string, string>
+  missingFiles: string[]
+}> {
+  const fileManifest: any = {}
+  const legacyStoragePaths: Record<string, string> = {}
+  const missingFiles: string[] = []
+
+  if (!files || files.length === 0) {
+    return { fileManifest, legacyStoragePaths, missingFiles }
+  }
+
+  const storage = getViralStorageService()
+
+  for (const file of files) {
+    const fileName = file.file
+    const s3Key = file.s3Key
+    const sizeFromJson = file.size
+
+    // Map file names to fileManifest keys
+    let manifestKey: string | null = null
+    if (fileName === 'input_log.jsonl') {
+      manifestKey = 'input_log'
+    } else if (fileName === 'meta.json') {
+      manifestKey = 'meta'
+    } else if (fileName === 'recording.mp4') {
+      manifestKey = 'recording'
+    }
+
+    if (!manifestKey) {
+      console.warn(`⚠️  Unknown file type: ${fileName}, skipping`)
+      continue
+    }
+
+    // Store legacy path
+    legacyStoragePaths[manifestKey] = s3Key
+
+    try {
+      // Check if file exists on ViralMind Tigris
+      const fileInfo = await storage.checkFileExists({ name: s3Key })
+
+      if (fileInfo.exists) {
+        fileManifest[manifestKey] = {
+          size: fileInfo.size || sizeFromJson,
+          hash: null // Hash will be calculated in future migration phase
+        }
+      } else {
+        missingFiles.push(`${fileName} (${s3Key})`)
+        console.warn(`⚠️  File not found in ViralMind storage: ${s3Key}`)
+      }
+    } catch (error: any) {
+      missingFiles.push(`${fileName} (${s3Key})`)
+      console.error(`❌ Error checking file ${s3Key}:`, error.message)
+    }
+  }
+
+  return { fileManifest, legacyStoragePaths, missingFiles }
+}
 
 /**
  * Load archived factories and create pool_id mapping
@@ -63,23 +163,21 @@ async function getPoolIdMapping(): Promise<Map<string, string>> {
 /**
  * Transform ViralMind submission to DemonstrationSubmission format
  */
-function transformSubmission(submission: any, poolIdMap: Map<string, string>) {
-  const poolId = submission.meta?.quest?.pool_id
+function transformSubmission(
+  submission: any,
+  _poolIdMap: Map<string, string>,
+  fileManifest: any,
+  legacyStoragePaths: Record<string, string>
+) {
   const taskId = submission.meta?.quest?.task_id
 
-  if (!poolId || !poolIdMap.has(poolId)) {
-    throw new Error(`Pool ID ${poolId} not found in archived factories`)
-  }
-
-  if (!taskId) {
-    throw new Error(`Task ID missing in submission ${submission._id}`)
-  }
+  // Note: poolId and taskId are already validated by caller
 
   // Generate demo hash using submission ID, address, and timestamp
   const timestamp = submission.meta?.timestamp ? new Date(submission.meta.timestamp).getTime() : Date.now()
   const demoHash = generateDemoHash(submission._id, OWNER_ADDRESS, timestamp)
 
-  // Create meta object with task_id properly set
+  // Create meta object with task_id properly set and legacy storage paths
   const meta = {
     ...submission.meta,
     quest: {
@@ -90,7 +188,8 @@ function transformSubmission(submission: any, poolIdMap: Map<string, string>) {
       major: 1,
       minor: 0,
       patch: 0
-    }
+    },
+    legacy_storage_paths: legacyStoragePaths
   }
 
   // Handle dates properly - use meta.timestamp or current time
@@ -116,8 +215,8 @@ function transformSubmission(submission: any, poolIdMap: Map<string, string>) {
     meta: meta,
     status: ForgeSubmissionProcessingStatus.COMPLETED,
     demoHash: demoHash,
-    fileManifest: null,
-    integrityVerified: false,
+    fileManifest: Object.keys(fileManifest).length > 0 ? fileManifest : null,
+    integrityVerified: false, // Files not yet migrated to new paths
     integrityLastCheck: null,
     grade_result: null,
     grading_metrics: null,
@@ -176,16 +275,30 @@ async function migrate() {
     const submissionsData = loadSubmissions()
 
     console.log('Starting demonstration migration...')
+    console.log('Initializing ViralMind storage service...')
+
+    // Initialize storage service early to validate credentials
+    try {
+      getViralStorageService()
+      console.log('✅ ViralMind storage service initialized successfully')
+    } catch (error: any) {
+      console.error('❌ Failed to initialize ViralMind storage service:', error.message)
+      console.error('Migration aborted. Please configure VIRAL_ACCESS_KEY, VIRAL_SECRET_ACCESS_KEY, and VIRAL_ENDPOINT environment variables.')
+      process.exit(1)
+    }
 
     const demonstrations: any[] = []
     let processed = 0
     let errors = 0
     let skippedNoPool = 0
+    let totalMissingFiles = 0
+    let submissionsWithMissingFiles = 0
     const errorStats = new Map<string, number>() // Track error types
 
     for (const submission of submissionsData) {
       try {
         const poolId = submission.meta?.quest?.pool_id
+        const taskId = submission.meta?.quest?.task_id
 
         // Skip submissions without valid pool_id mapping
         if (!poolId || !poolIdMap.has(poolId)) {
@@ -193,7 +306,21 @@ async function migrate() {
           continue
         }
 
-        const demonstration = transformSubmission(submission, poolIdMap)
+        // Validate task_id exists BEFORE making network calls
+        if (!taskId) {
+          throw new Error(`Task ID missing in submission ${submission._id}`)
+        }
+
+        // Build file manifest from ViralMind files (makes network calls)
+        const { fileManifest, legacyStoragePaths, missingFiles } = await buildFileManifest(submission.files || [])
+
+        if (missingFiles.length > 0) {
+          submissionsWithMissingFiles++
+          totalMissingFiles += missingFiles.length
+          console.warn(`⚠️  Submission ${submission._id}: ${missingFiles.length} missing file(s)`)
+        }
+
+        const demonstration = transformSubmission(submission, poolIdMap, fileManifest, legacyStoragePaths)
         demonstrations.push(demonstration)
         processed++
 
@@ -206,7 +333,12 @@ async function migrate() {
             'transformation_error'
 
         errorStats.set(errorType, (errorStats.get(errorType) || 0) + 1)
-        console.error(`Error processing submission ${submission._id}:`, error.message)
+
+        // Only log first 10 errors of each type to avoid spam
+        const errorCount = errorStats.get(errorType) || 0
+        if (errorCount <= 10) {
+          console.error(`Error processing submission ${submission._id}:`, error.message)
+        }
         errors++
       }
     }
@@ -216,6 +348,8 @@ async function migrate() {
     console.log(`- Processed: ${processed}`)
     console.log(`- Skipped (no pool mapping): ${skippedNoPool}`)
     console.log(`- Errors: ${errors}`)
+    console.log(`- Submissions with missing files: ${submissionsWithMissingFiles}`)
+    console.log(`- Total missing files: ${totalMissingFiles}`)
 
     // Error breakdown
     if (errorStats.size > 0) {

--- a/scripts/viralmind-migration/migrate-generate-sft.ts
+++ b/scripts/viralmind-migration/migrate-generate-sft.ts
@@ -1,0 +1,696 @@
+#!/usr/bin/env node
+
+/**
+ * Migration script to generate sft.json files for legacy demonstration submissions
+ *
+ * This script:
+ * 1. Reads demonstration_submissions with legacy_storage_paths
+ * 2. Downloads files from ViralMind Tigris storage to temp directory
+ * 3. Runs CQA (Clones Quality Agent) to generate sft.json
+ * 4. Saves sft.json to project directory with recording ID structure
+ * 5. Updates legacy_storage_paths with sft.json path
+ *
+ * Usage: npx tsx scripts/migrate-generate-sft.ts [environment] [--limit N]
+ * Environment: development (default), test, production
+ * --limit N: Process only first N submissions (default: 1 for testing)
+ * 
+ * DB_URI="mongodb://admin:admin@localhost:27017/dev?authSource=admin" CONNECT_TOKEN="" BACKEND_URL="http://localhost:8001" npx tsx scripts/migrate-generate-sft.ts development
+ */
+
+import { config } from 'dotenv'
+import { promises as fs } from 'fs'
+import * as path from 'path'
+import FormData from 'form-data'
+import axios from 'axios'
+
+// Load environment variables from .env file
+config()
+
+import mongoose from 'mongoose'
+import { DemonstrationSubmission } from '../../src/models/DemonstrationSubmission.ts'
+import { ObjectStorageService } from '../../src/services/storage/index.ts'
+import { generateDemoHash, calculateFileHash, calculateOverallHash, getDemoStoragePath } from '../../src/services/demo-storage/hash.ts'
+
+// Parse command line arguments
+const args = process.argv.slice(2)
+const environment = args.find(arg => !arg.startsWith('--')) || 'development'
+const limitArg = args.find(arg => arg.startsWith('--limit'))
+const limit = limitArg ? parseInt(limitArg.split('=')[1]) : 1
+
+const validEnvironments = ['development', 'test', 'production']
+
+if (!validEnvironments.includes(environment)) {
+  console.error(`❌ Invalid environment: ${environment}`)
+  console.error(`Valid environments: ${validEnvironments.join(', ')}`)
+  process.exit(1)
+}
+
+console.log(`🚀 Running SFT generation migration for environment: ${environment}`)
+console.log(`📊 Processing limit: ${limit} submission(s)`)
+
+// MongoDB connection
+const MONGODB_URI = process.env.DB_URI || 'mongodb://admin:admin@localhost:27017/dev?authSource=admin'
+
+// ViralMind Tigris storage configuration (legacy data source)
+const VIRAL_ACCESS_KEY = process.env.VIRAL_ACCESS_KEY
+const VIRAL_SECRET_ACCESS_KEY = process.env.VIRAL_SECRET_ACCESS_KEY
+const VIRAL_ENDPOINT = process.env.VIRAL_ENDPOINT
+const VIRAL_BUCKET = 'clones-bucket-prod'
+const VIRAL_REGION = 'auto'
+
+// Clones Tigris storage configuration (new data destination)
+const CLONES_ACCESS_KEY = process.env.CLONES_BUCKET_ACCESS_KEY
+const CLONES_SECRET_ACCESS_KEY = process.env.CLONES_BUCKET_SECRET_ACCESS_KEY
+const CLONES_ENDPOINT = process.env.CLONES_BUCKET_ENDPOINT
+const CLONES_BUCKET = process.env.CLONES_BUCKET_NAME || 'clones-storage-prod'
+const CLONES_REGION = 'auto'
+
+// Backend API configuration
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:3000'
+const CONNECT_TOKEN = process.env.CONNECT_TOKEN // Authentication token for API
+
+// Output directory for generated sft.json files (local backup)
+const SFT_OUTPUT_DIR = path.join(process.cwd(), 'data', 'sft_files')
+
+// Initialize ViralMind storage service (legacy source)
+let viralStorageService: ObjectStorageService | null = null
+
+function getViralStorageService(): ObjectStorageService {
+  if (!viralStorageService) {
+    if (!VIRAL_ACCESS_KEY || !VIRAL_SECRET_ACCESS_KEY || !VIRAL_ENDPOINT) {
+      throw new Error('ViralMind Tigris credentials not configured. Please set VIRAL_ACCESS_KEY, VIRAL_SECRET_ACCESS_KEY, and VIRAL_ENDPOINT environment variables.')
+    }
+    viralStorageService = new ObjectStorageService(
+      VIRAL_ACCESS_KEY,
+      VIRAL_SECRET_ACCESS_KEY,
+      VIRAL_ENDPOINT,
+      VIRAL_REGION,
+      VIRAL_BUCKET
+    )
+  }
+  return viralStorageService
+}
+
+// Initialize Clones storage service (new destination)
+let clonesStorageService: ObjectStorageService | null = null
+
+function getClonesStorageService(): ObjectStorageService {
+  if (!clonesStorageService) {
+    if (!CLONES_ACCESS_KEY || !CLONES_SECRET_ACCESS_KEY || !CLONES_ENDPOINT) {
+      throw new Error('Clones Tigris credentials not configured. Please set CLONES_BUCKET_ACCESS_KEY, CLONES_BUCKET_SECRET_ACCESS_KEY, and CLONES_BUCKET_ENDPOINT environment variables.')
+    }
+    clonesStorageService = new ObjectStorageService(
+      CLONES_ACCESS_KEY,
+      CLONES_SECRET_ACCESS_KEY,
+      CLONES_ENDPOINT,
+      CLONES_REGION,
+      CLONES_BUCKET
+    )
+  }
+  return clonesStorageService
+}
+
+/**
+ * Download recording files from ViralMind Tigris to a temporary directory
+ */
+async function downloadRecordingFiles(
+  legacyStoragePaths: Record<string, string>,
+  tempDir: string
+): Promise<void> {
+  const storage = getViralStorageService()
+
+  // Files we need for CQA processing
+  const requiredFiles = ['recording', 'meta', 'input_log']
+  const fileMapping = {
+    'recording': 'recording.mp4',
+    'meta': 'meta.json',
+    'input_log': 'input_log.jsonl'
+  }
+
+  for (const [key, filename] of Object.entries(fileMapping)) {
+    const s3Key = legacyStoragePaths[key]
+
+    if (!s3Key) {
+      console.warn(`⚠️  Missing ${key} in legacy_storage_paths, skipping`)
+      continue
+    }
+
+    try {
+      console.log(`📥 Downloading ${filename} from ${s3Key}...`)
+
+      // Download file from Tigris
+      const fileBuffer = await storage.getItem({ name: s3Key })
+
+      // Save to temp directory
+      const targetPath = path.join(tempDir, filename)
+      await fs.writeFile(targetPath, fileBuffer)
+
+      const stats = await fs.stat(targetPath)
+      console.log(`✅ Downloaded ${filename} (${stats.size} bytes)`)
+
+    } catch (error: any) {
+      console.error(`❌ Failed to download ${filename}:`, error.message)
+      throw error
+    }
+  }
+
+  // Patch meta.json to add schema_version if missing (legacy data compatibility)
+  const metaPath = path.join(tempDir, 'meta.json')
+  try {
+    console.log(`🔧 Patching meta.json to add schema_version...`)
+    const metaContent = await fs.readFile(metaPath, 'utf8')
+    const metaJson = JSON.parse(metaContent)
+
+    // Add schema_version if missing or invalid
+    if (!metaJson.schema_version || typeof metaJson.schema_version !== 'object') {
+      metaJson.schema_version = { major: 1, minor: 0, patch: 0 }
+      await fs.writeFile(metaPath, JSON.stringify(metaJson, null, 2))
+      console.log(`✅ Added schema_version to meta.json`)
+    } else {
+      console.log(`✅ meta.json already has schema_version`)
+    }
+  } catch (error: any) {
+    console.warn(`⚠️  Failed to patch meta.json: ${error.message}`)
+  }
+
+  // Create input_log_meta.json if it doesn't exist
+  const inputLogMetaPath = path.join(tempDir, 'input_log_meta.json')
+  try {
+    await fs.access(inputLogMetaPath)
+  } catch {
+    console.log(`📝 Creating input_log_meta.json...`)
+    const inputLogMeta = {
+      schema_version: { major: 1, minor: 0, patch: 0 },
+      format: "jsonl",
+      event_count: 0,
+      timestamp_type: "relative",
+      created_at: new Date().toISOString()
+    }
+    await fs.writeFile(inputLogMetaPath, JSON.stringify(inputLogMeta, null, 2))
+  }
+}
+
+/**
+ * Call backend API to generate sft.json via CQA
+ */
+async function generateSftViaBackend(inputDir: string, submissionId: string): Promise<void> {
+  console.log(`🔧 Calling backend API to generate sft.json for submission: ${submissionId}`)
+
+  // Check if directory exists and has files
+  const files = await fs.readdir(inputDir)
+  console.log(`📁 Directory contents: ${files.join(', ')}`)
+
+  if (files.length === 0) {
+    throw new Error('No files found in input directory')
+  }
+
+  // Create form data with files
+  const form = new FormData()
+
+  for (const filename of files) {
+    const filePath = path.join(inputDir, filename)
+    const fileBuffer = await fs.readFile(filePath)
+    form.append('files', fileBuffer, filename)
+  }
+
+  // Call backend API
+  const apiUrl = `${BACKEND_URL}/api/v1/forge/recordings/${submissionId}/process`
+  console.log(`🚀 Calling: POST ${apiUrl}`)
+  console.log(`⏳ This may take a while (CQA processing)...`)
+
+  try {
+    const response = await axios.post(apiUrl, form, {
+      headers: {
+        ...form.getHeaders(),
+        'x-connect-token': CONNECT_TOKEN || ''
+      },
+      maxContentLength: Infinity,
+      maxBodyLength: Infinity,
+      timeout: 300000 // 5 minutes timeout for CQA processing
+    })
+
+    console.log(`✅ Backend responded with status: ${response.status}`)
+
+    console.log(`📦 Response data structure:`, {
+      success: response.data.success,
+      hasData: !!response.data.data,
+      hasGeneratedFiles: !!(response.data.data && response.data.data.generatedFiles),
+      generatedFilesCount: response.data.data?.generatedFiles ? Object.keys(response.data.data.generatedFiles).length : 0
+    })
+
+    if (response.data.success && response.data.data.generatedFiles) {
+      const generatedFiles = response.data.data.generatedFiles
+      console.log(`✅ Backend generated ${Object.keys(generatedFiles).length} files: ${Object.keys(generatedFiles).join(', ')}`)
+
+      // Save sft.json to temp directory
+      if (generatedFiles['sft.json']) {
+        const sftPath = path.join(inputDir, 'sft.json')
+        console.log(`💾 Writing sft.json to ${sftPath}...`)
+        await fs.writeFile(sftPath, generatedFiles['sft.json'])
+        const stats = await fs.stat(sftPath)
+        console.log(`✅ Saved sft.json (${stats.size} bytes)`)
+      } else {
+        throw new Error('Backend did not generate sft.json')
+      }
+    } else {
+      console.error(`❌ Unexpected response structure:`, JSON.stringify(response.data, null, 2))
+      throw new Error('Backend API response was not successful')
+    }
+  } catch (error: any) {
+    if (error.response) {
+      console.error(`❌ Backend API error: ${error.response.status} ${error.response.statusText}`)
+      console.error(`Response:`, error.response.data)
+      throw new Error(`Backend API failed: ${error.response.status} - ${JSON.stringify(error.response.data)}`)
+    } else if (error.code === 'ECONNREFUSED') {
+      console.error(`❌ Cannot connect to backend at ${BACKEND_URL}`)
+      console.error(`Make sure the backend server is running with: npm run dev`)
+      throw new Error(`Backend not running - connection refused to ${BACKEND_URL}`)
+    } else if (error.code === 'ECONNABORTED' || error.message.includes('timeout')) {
+      console.error(`❌ Backend API timeout after 5 minutes`)
+      console.error(`CQA processing took too long - this might indicate an issue with the recording files`)
+      throw new Error(`Backend API timeout - CQA processing took longer than 5 minutes`)
+    } else {
+      console.error(`❌ Backend API request error:`, error)
+      console.error(`Error code: ${error.code}`)
+      console.error(`Error message: ${error.message}`)
+      throw new Error(`Backend API request failed: ${error.message}`)
+    }
+  }
+}
+
+/**
+ * Transform input_log.jsonl timestamps from absolute Unix time to relative time
+ */
+async function transformInputLogTimestamps(tempDir: string): Promise<void> {
+  console.log(`🕐 Transforming input_log.jsonl timestamps to relative time...`)
+
+  const metaPath = path.join(tempDir, 'meta.json')
+  const inputLogPath = path.join(tempDir, 'input_log.jsonl')
+
+  // Read meta.json to get the start timestamp
+  const metaContent = await fs.readFile(metaPath, 'utf8')
+  const meta = JSON.parse(metaContent)
+
+  let startTimestamp: number
+  if (meta.timestamp) {
+    // Parse ISO timestamp to Unix milliseconds
+    startTimestamp = new Date(meta.timestamp).getTime()
+  } else {
+    console.warn(`⚠️  No timestamp found in meta.json, using first event timestamp as reference`)
+    // We'll determine it from the first event
+    const inputLogContent = await fs.readFile(inputLogPath, 'utf8')
+    const lines = inputLogContent.trim().split('\n')
+    if (lines.length > 0) {
+      const firstEvent = JSON.parse(lines[0])
+      startTimestamp = firstEvent.time || 0
+    } else {
+      throw new Error('input_log.jsonl is empty')
+    }
+  }
+
+  console.log(`   Start timestamp: ${startTimestamp} (${new Date(startTimestamp).toISOString()})`)
+
+  // Read and transform input_log.jsonl
+  const inputLogContent = await fs.readFile(inputLogPath, 'utf8')
+  const lines = inputLogContent.trim().split('\n')
+  const transformedLines: string[] = []
+
+  let minTime = Infinity
+  let maxTime = -Infinity
+  let transformedCount = 0
+
+  for (const line of lines) {
+    if (!line.trim()) continue
+
+    const event = JSON.parse(line)
+
+    // Transform absolute timestamp to relative
+    if (typeof event.time === 'number') {
+      const relativeTime = event.time - startTimestamp
+      event.time = relativeTime
+
+      minTime = Math.min(minTime, relativeTime)
+      maxTime = Math.max(maxTime, relativeTime)
+      transformedCount++
+    }
+
+    transformedLines.push(JSON.stringify(event))
+  }
+
+  // Write transformed input_log.jsonl
+  await fs.writeFile(inputLogPath, transformedLines.join('\n') + '\n')
+
+  console.log(`✅ Transformed ${transformedCount} events`)
+  console.log(`   Time range: ${minTime}ms to ${maxTime}ms (${(maxTime / 1000).toFixed(2)}s duration)`)
+}
+
+/**
+ * Upload demonstration files to Clones Tigris storage with integrity tracking
+ * Stores in datasets/computer-use-v0/ for migrated legacy data
+ */
+async function uploadToTigris(
+  tempDir: string,
+  submission: any
+): Promise<{
+  demoHash: string
+  fileManifest: Record<string, { size: number; hash: string }>
+  overallHash: string
+}> {
+  console.log(`☁️  Uploading files to Clones Tigris storage...`)
+
+  const storage = getClonesStorageService()
+
+  // Transform input_log timestamps to relative time before upload
+  await transformInputLogTimestamps(tempDir)
+
+  // Generate demoHash from submission data
+  const timestamp = submission.createdAt ? new Date(submission.createdAt).getTime() : Date.now()
+  const demoHash = generateDemoHash(submission._id, submission.address, timestamp)
+
+  console.log(`🔑 Generated demoHash: ${demoHash}`)
+
+  // Files to upload
+  const filesToUpload = [
+    { filename: 'recording.mp4', required: true },
+    { filename: 'meta.json', required: true },
+    { filename: 'input_log.jsonl', required: true },
+    { filename: 'sft.json', required: true }
+  ]
+
+  const fileManifest: Record<string, { size: number; hash: string }> = {}
+  const fileHashes: string[] = []
+
+  for (const { filename, required } of filesToUpload) {
+    const filePath = path.join(tempDir, filename)
+
+    try {
+      await fs.access(filePath)
+    } catch {
+      if (required) {
+        throw new Error(`Required file ${filename} not found in temp directory`)
+      }
+      console.warn(`⚠️  Optional file ${filename} not found, skipping`)
+      continue
+    }
+
+    const fileBuffer = await fs.readFile(filePath)
+    const fileHash = calculateFileHash(fileBuffer)
+    const fileSize = fileBuffer.length
+
+    // Use v0 path for legacy migrated data (getDemoStoragePath with 'v0')
+    const storagePath = `datasets/computer-use-v0/demonstrations/${demoHash}/${filename}`
+
+    console.log(`📤 Uploading ${filename} (${fileSize} bytes, hash: ${fileHash.substring(0, 16)}...)`)
+
+    await storage.saveItem({
+      name: storagePath,
+      file: fileBuffer
+    })
+
+    // Map filename to manifest key
+    let manifestKey: string
+    if (filename === 'recording.mp4') manifestKey = 'recording'
+    else if (filename === 'meta.json') manifestKey = 'meta'
+    else if (filename === 'input_log.jsonl') manifestKey = 'input_log'
+    else if (filename === 'sft.json') manifestKey = 'sft'
+    else continue
+
+    fileManifest[manifestKey] = {
+      size: fileSize,
+      hash: fileHash
+    }
+
+    fileHashes.push(fileHash)
+    console.log(`✅ Uploaded ${filename}`)
+  }
+
+  // Calculate overall integrity hash
+  const overallHash = calculateOverallHash(fileHashes)
+  console.log(`🔒 Overall integrity hash: ${overallHash.substring(0, 16)}...`)
+
+  // Create integrity manifest (checksums.json)
+  const integrityManifest = {
+    schema_version: { major: 1, minor: 0, patch: 0 },
+    demoHash,
+    submissionId: submission._id,
+    userAddress: submission.address.toLowerCase(),
+    timestamp,
+    files: Object.entries(fileManifest).map(([key, value]) => {
+      // Map manifest keys back to filenames
+      let filename: string
+      if (key === 'recording') filename = 'recording.mp4'
+      else if (key === 'meta') filename = 'meta.json'
+      else if (key === 'input_log') filename = 'input_log.jsonl'
+      else if (key === 'sft') filename = 'sft.json'
+      else filename = key
+
+      return {
+        filename,
+        sha256: value.hash,
+        size: value.size,
+        lastModified: new Date().toISOString()
+      }
+    }),
+    overallHash
+  }
+
+  // Upload checksums.json
+  const checksumPath = `datasets/computer-use-v0/demonstrations/${demoHash}/checksums.json`
+  console.log(`📤 Uploading checksums.json...`)
+  await storage.saveItem({
+    name: checksumPath,
+    file: Buffer.from(JSON.stringify(integrityManifest, null, 2))
+  })
+  console.log(`✅ Uploaded checksums.json`)
+
+  return {
+    demoHash,
+    fileManifest,
+    overallHash
+  }
+}
+
+/**
+ * Save sft.json to local project directory as backup
+ */
+async function saveLocalBackup(tempDir: string, submissionId: string): Promise<string> {
+  // Create output directory structure: data/sft_files/{submissionId}/
+  const submissionDir = path.join(SFT_OUTPUT_DIR, submissionId)
+  await fs.mkdir(submissionDir, { recursive: true })
+
+  // Save sft.json
+  const sftJsonSourcePath = path.join(tempDir, 'sft.json')
+  const sftJsonTargetPath = path.join(submissionDir, 'sft.json')
+  await fs.copyFile(sftJsonSourcePath, sftJsonTargetPath)
+  const sftJsonStats = await fs.stat(sftJsonTargetPath)
+  console.log(`💾 Saved local backup to ${sftJsonTargetPath} (${sftJsonStats.size} bytes)`)
+
+  // Return relative path from project root for sft.json
+  return path.relative(process.cwd(), sftJsonTargetPath)
+}
+
+/**
+ * Process a single demonstration submission
+ */
+async function processSubmission(submission: any): Promise<boolean> {
+  //console.log(`\n${'='.repeat(80)}`)
+  //console.log(`📝 Processing submission: ${submission._id}`)
+  //console.log(`${'='.repeat(80)}`)
+
+  // Check if already processed by looking at local backup directory
+  const submissionDir = path.join(SFT_OUTPUT_DIR, submission._id)
+  try {
+    await fs.access(submissionDir)
+    //console.log(`⏭️  Skipping - already processed (found in ${submissionDir})`)
+    return false
+  } catch {
+    // Not processed yet, continue
+  }
+
+  // Check if legacy_storage_paths exists
+  if (!submission.meta?.legacy_storage_paths) {
+    console.log(`⏭️  Skipping - no legacy_storage_paths found for ${submission._id}`)
+    return false
+  }
+
+  const legacyPaths = submission.meta.legacy_storage_paths
+  console.log(`📂 Legacy storage paths:`)
+  console.log(`   - recording: ${legacyPaths.recording || 'N/A'}`)
+  console.log(`   - meta: ${legacyPaths.meta || 'N/A'}`)
+  console.log(`   - input_log: ${legacyPaths.input_log || 'N/A'}`)
+
+  // Create temporary directory for processing
+  const tempDir = path.join(process.cwd(), 'temp', `sft_gen_${submission._id}`)
+
+  try {
+    // Create temp directory
+    await fs.mkdir(tempDir, { recursive: true })
+    console.log(`📁 Created temp directory: ${tempDir} for ${submission._id}`)
+
+    // Step 1: Download files from ViralMind Tigris
+    console.log(`\n📥 Step 1: Downloading files from ViralMind Tigris...`)
+    await downloadRecordingFiles(legacyPaths, tempDir)
+
+    // Step 2: Call backend API to generate sft.json
+    console.log(`\n🔧 Step 2: Calling backend API to generate sft.json...`)
+    await generateSftViaBackend(tempDir, submission._id)
+
+    // Step 3: Upload files to Clones Tigris storage with integrity tracking
+    console.log(`\n☁️  Step 3: Uploading to Clones Tigris storage...`)
+    const { demoHash, fileManifest, overallHash } = await uploadToTigris(tempDir, submission)
+
+    // Step 4: Save local backup of sft.json
+    console.log(`\n💾 Step 4: Saving local backup...`)
+    const sftRelativePath = await saveLocalBackup(tempDir, submission._id)
+
+    // Step 5: Clean up temp directory immediately to free disk space
+    console.log(`\n🧹 Step 5: Cleaning up temp files to free disk space...`)
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true })
+      console.log(`✅ Cleaned up temp directory: ${tempDir}`)
+    } catch (cleanupError: any) {
+      console.warn(`⚠️  Failed to cleanup temp directory: ${cleanupError.message}`)
+    }
+
+    // Step 6: Update database with demoHash, fileManifest, and integrity info
+    console.log(`\n💿 Step 6: Updating database...`)
+    const now = new Date()
+    await DemonstrationSubmission.findByIdAndUpdate(
+      submission._id,
+      {
+        $set: {
+          demoHash: demoHash,
+          fileManifest: fileManifest,
+          integrityVerified: true,
+          integrityLastCheck: now,
+          'meta.legacy_storage_paths.sft': sftRelativePath,
+          'meta.overall_hash': overallHash
+        }
+      }
+    )
+    console.log(`✅ Updated database:`)
+    console.log(`   - demoHash: ${demoHash}`)
+    console.log(`   - fileManifest: ${Object.keys(fileManifest).length} files`)
+    console.log(`   - integrityVerified: true`)
+    console.log(`   - integrityLastCheck: ${now.toISOString()}`)
+    console.log(`   - legacy_storage_paths.sft: ${sftRelativePath}`)
+
+    console.log(`\n🎉 Successfully processed submission ${submission._id}`)
+    return true
+
+  } catch (error: any) {
+    console.error(`\n❌ Failed to process submission ${submission._id}:`, error.message)
+
+    // Clean up temp directory on error as well
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true })
+      console.log(`🧹 Cleaned up temp directory after error: ${tempDir}`)
+    } catch (cleanupError: any) {
+      console.warn(`⚠️  Failed to cleanup temp directory: ${cleanupError.message}`)
+    }
+
+    return false
+  }
+}
+
+/**
+ * Connect to MongoDB
+ */
+async function connectToMongo() {
+  console.log(`Connecting to MongoDB: ${MONGODB_URI}`)
+  await mongoose.connect(MONGODB_URI)
+  console.log('Connected to MongoDB')
+}
+
+/**
+ * Main migration function
+ */
+async function migrate() {
+  try {
+    // Validate ViralMind Tigris credentials (legacy source)
+    if (!VIRAL_ACCESS_KEY || !VIRAL_SECRET_ACCESS_KEY || !VIRAL_ENDPOINT) {
+      console.error('❌ ViralMind Tigris credentials not configured')
+      console.error('Please set VIRAL_ACCESS_KEY, VIRAL_SECRET_ACCESS_KEY, and VIRAL_ENDPOINT')
+      process.exit(1)
+    }
+
+    // Validate Clones Tigris credentials (new destination)
+    if (!CLONES_ACCESS_KEY || !CLONES_SECRET_ACCESS_KEY || !CLONES_ENDPOINT) {
+      console.error('❌ Clones Tigris credentials not configured')
+      console.error('Please set CLONES_BUCKET_ACCESS_KEY, CLONES_BUCKET_SECRET_ACCESS_KEY, and CLONES_BUCKET_ENDPOINT')
+      process.exit(1)
+    }
+
+    // Validate backend configuration
+    console.log(`🔗 Backend URL: ${BACKEND_URL}`)
+    console.log(`☁️  Clones Tigris Bucket: ${CLONES_BUCKET}`)
+    console.log(`📁 Storage path: datasets/computer-use-v0/`)
+    if (CONNECT_TOKEN) {
+      console.log(`🔐 Using connect token: ${CONNECT_TOKEN.substring(0, 10)}...`)
+    } else {
+      console.warn('⚠️  No CONNECT_TOKEN provided - API calls may require authentication')
+    }
+
+    // Connect to database
+    await connectToMongo()
+
+    console.log('\n🔍 Looking for demonstration submissions with legacy_storage_paths...')
+
+    // Find submissions with legacy_storage_paths
+    // Note: We check local directory existence for skip logic, not DB field
+    const submissions = await DemonstrationSubmission.find({
+      'meta.legacy_storage_paths': { $exists: true }
+    })
+      .limit(limit)
+      .lean()
+
+    console.log(`📊 Found ${submissions.length} submission(s) to process`)
+
+    if (submissions.length === 0) {
+      console.log('\n✅ No submissions to process. All done!')
+      return
+    }
+
+    let processed = 0
+    let successful = 0
+    let failed = 0
+
+    for (const submission of submissions) {
+      processed++
+      //console.log(`\n📊 Progress: ${processed}/${submissions.length}`)
+
+      const success = await processSubmission(submission)
+      if (success) {
+        successful++
+      } else {
+        failed++
+      }
+    }
+
+    console.log(`\n${'='.repeat(80)}`)
+    console.log(`📊 Migration Summary:`)
+    console.log(`   - Total processed: ${processed}`)
+    console.log(`   - Successful: ${successful}`)
+    console.log(`   - Failed: ${failed}`)
+    console.log(`${'='.repeat(80)}`)
+
+    console.log('\n🎉 Migration completed!')
+
+  } catch (error) {
+    console.error('❌ Migration failed:', error)
+    process.exit(1)
+  } finally {
+    await mongoose.disconnect()
+    console.log('Disconnected from MongoDB')
+  }
+}
+
+// Run migration if this script is executed directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  migrate().catch(error => {
+    console.error('Fatal error:', error)
+    process.exit(1)
+  })
+}
+
+export { migrate }

--- a/scripts/viralmind-migration/migrate-grade-demos.ts
+++ b/scripts/viralmind-migration/migrate-grade-demos.ts
@@ -6,6 +6,10 @@
  * This script calls the backend API to grade demonstrations, which handles all CQA logic.
  * This approach works regardless of where the script is run (local macOS, Docker, etc.)
  *
+ * Required environment variables:
+ * - ADMIN_TOKEN: Admin authentication token for grading API endpoints
+ * - DB_URI: MongoDB connection string
+ *
  * Usage: npx tsx scripts/migrate-grade-demos-api.ts [environment] [--limit N] [--backend-url URL]
  * Environment: development (default), test, production
  * --limit N: Process only first N submissions (default: 1 for testing)
@@ -51,10 +55,16 @@ async function gradeSubmissionViaAPI(submissionId: string): Promise<any> {
 
   console.log(`📡 Calling API: POST ${url}`)
 
+  const adminToken = process.env.ADMIN_TOKEN
+  if (!adminToken) {
+    throw new Error('ADMIN_TOKEN environment variable is required for grading API')
+  }
+
   const response = await fetch(url, {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      'x-admin-token': adminToken
     }
   })
 
@@ -136,7 +146,6 @@ async function grade() {
       demoHash: {
         $exists: true,
         $ne: null,
-        $eq: "46cc5603156ccb88770570416dfdd642b9cfe21f0b11da6f3d5ed0a299bd8b78",
       },
       $or: [
         { grade_result: { $exists: false } },

--- a/scripts/viralmind-migration/migrate-grade-demos.ts
+++ b/scripts/viralmind-migration/migrate-grade-demos.ts
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+
+/**
+ * Migration script to grade legacy demonstration submissions using CQA via API
+ *
+ * This script calls the backend API to grade demonstrations, which handles all CQA logic.
+ * This approach works regardless of where the script is run (local macOS, Docker, etc.)
+ *
+ * Usage: npx tsx scripts/migrate-grade-demos-api.ts [environment] [--limit N] [--backend-url URL]
+ * Environment: development (default), test, production
+ * --limit N: Process only first N submissions (default: 1 for testing)
+ * --backend-url URL: Backend URL (default: http://localhost:8001)
+ */
+
+import { config } from 'dotenv'
+
+// Load environment variables from .env file
+config()
+
+import mongoose from 'mongoose'
+import { DemonstrationSubmission } from '../../src/models/DemonstrationSubmission.ts'
+
+// Parse command line arguments
+const args = process.argv.slice(2)
+const environment = args.find(arg => !arg.startsWith('--')) || 'development'
+const limitArg = args.find(arg => arg.startsWith('--limit'))
+const limit = limitArg ? parseInt(limitArg.split('=')[1]) : 1
+const backendUrlArg = args.find(arg => arg.startsWith('--backend-url'))
+const BACKEND_URL = backendUrlArg ? backendUrlArg.split('=')[1] : (process.env.BACKEND_URL || 'http://localhost:8001')
+
+const validEnvironments = ['development', 'test', 'production']
+
+if (!validEnvironments.includes(environment)) {
+  console.error(`❌ Invalid environment: ${environment}`)
+  console.error(`Valid environments: ${validEnvironments.join(', ')}`)
+  process.exit(1)
+}
+
+console.log(`🚀 Running demonstration grading migration for environment: ${environment}`)
+console.log(`📊 Processing limit: ${limit} submission(s)`)
+console.log(`🌐 Backend URL: ${BACKEND_URL}`)
+
+// MongoDB connection
+const MONGODB_URI = process.env.DB_URI || 'mongodb://admin:admin@localhost:27017/dev?authSource=admin'
+
+/**
+ * Grade a submission via API
+ */
+async function gradeSubmissionViaAPI(submissionId: string): Promise<any> {
+  const url = `${BACKEND_URL}/api/v1/forge/grading/grade-submission/${submissionId}`
+
+  console.log(`📡 Calling API: POST ${url}`)
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  })
+
+  if (!response.ok) {
+    const errorText = await response.text()
+    throw new Error(`API request failed with status ${response.status}: ${errorText}`)
+  }
+
+  return await response.json()
+}
+
+/**
+ * Process a single demonstration submission for grading
+ */
+async function processSubmission(submission: any): Promise<boolean> {
+  console.log(`\n${'='.repeat(80)}`)
+  console.log(`📝 Processing submission: ${submission._id}`)
+  console.log(`${'='.repeat(80)}`)
+
+  // Check if demoHash exists
+  if (!submission.demoHash) {
+    console.log(`⏭️  Skipping - no demoHash found (not migrated yet?)`)
+    return false
+  }
+
+  // Check if already graded
+  if (submission.grade_result && submission.grade_result.score !== null && submission.grade_result.score !== undefined) {
+    console.log(`⏭️  Skipping - already graded (score: ${submission.grade_result.score})`)
+    return false
+  }
+
+  console.log(`🔑 DemoHash: ${submission.demoHash}`)
+  console.log(`👤 Address: ${submission.address}`)
+
+  try {
+    // Call API to grade submission
+    const result = await gradeSubmissionViaAPI(submission._id)
+
+    if (result.alreadyGraded) {
+      console.log(`⏭️  Already graded (score: ${result.gradeResult.score})`)
+      return false
+    }
+
+    console.log(`✅ Successfully graded submission ${submission._id}`)
+    console.log(`   - grade_result.score: ${result.gradeResult.score}`)
+    console.log(`   - clampedScore: ${result.clampedScore}`)
+    console.log(`   - grading_metrics: ${result.gradingMetrics ? 'yes' : 'no'}`)
+
+    return true
+
+  } catch (error: any) {
+    console.error(`\n❌ Failed to grade submission ${submission._id}:`, error.message)
+    return false
+  }
+}
+
+/**
+ * Connect to MongoDB
+ */
+async function connectToMongo() {
+  console.log(`Connecting to MongoDB: ${MONGODB_URI}`)
+  await mongoose.connect(MONGODB_URI)
+  console.log('Connected to MongoDB')
+}
+
+/**
+ * Main grading function
+ */
+async function grade() {
+  try {
+    // Connect to database
+    await connectToMongo()
+
+    console.log('\n🔍 Looking for demonstration submissions to grade...')
+
+    // Find submissions with legacy_storage_paths and null grade_result
+    const submissions = await DemonstrationSubmission.find({
+      'meta.legacy_storage_paths': { $exists: true },
+      demoHash: {
+        $exists: true,
+        $ne: null,
+        $eq: "46cc5603156ccb88770570416dfdd642b9cfe21f0b11da6f3d5ed0a299bd8b78",
+      },
+      $or: [
+        { grade_result: { $exists: false } },
+        { grade_result: null },
+        { 'grade_result.score': { $exists: false } },
+        { 'grade_result.score': null }
+      ]
+    })
+      .limit(limit)
+      .lean()
+
+    console.log(`📊 Found ${submissions.length} submission(s) to grade`)
+
+    if (submissions.length === 0) {
+      console.log('\n✅ No submissions to grade. All done!')
+      return
+    }
+
+    let processed = 0
+    let successful = 0
+    let failed = 0
+
+    for (const submission of submissions) {
+      processed++
+      console.log(`\n📊 Progress: ${processed}/${submissions.length}`)
+
+      const success = await processSubmission(submission)
+      if (success) {
+        successful++
+      } else {
+        failed++
+      }
+    }
+
+    console.log(`\n${'='.repeat(80)}`)
+    console.log(`📊 Grading Summary:`)
+    console.log(`   - Total processed: ${processed}`)
+    console.log(`   - Successful: ${successful}`)
+    console.log(`   - Failed: ${failed}`)
+    console.log(`${'='.repeat(80)}`)
+
+    console.log('\n🎉 Grading migration completed!')
+
+  } catch (error) {
+    console.error('❌ Grading migration failed:', error)
+    process.exit(1)
+  } finally {
+    await mongoose.disconnect()
+    console.log('Disconnected from MongoDB')
+  }
+}
+
+// Run grading if this script is executed directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  grade().catch(error => {
+    console.error('Fatal error:', error)
+    process.exit(1)
+  })
+}
+
+export { grade }
+

--- a/scripts/viralmind-migration/migrate-viralmind-data.ts
+++ b/scripts/viralmind-migration/migrate-viralmind-data.ts
@@ -9,8 +9,8 @@
 
 import { readFileSync } from 'fs'
 import mongoose, { Types } from 'mongoose'
-import { FactoryModel, type IFactoryDocument } from '../src/models/Factory.ts'
-import { FactoryStatus } from '../src/types/factory.ts'
+import { FactoryModel, type IFactoryDocument } from '../../src/models/Factory.ts'
+import { FactoryStatus } from '../../src/types/factory.ts'
 
 // Get environment from command line or default to development
 const environment = process.argv[2] || 'development'
@@ -29,9 +29,7 @@ const TRAINING_POOLS_PATH = '/Users/SSe/SSe/app/Clones-workspace/clones-quality-
 const FORGE_APPS_PATH = '/Users/SSe/SSe/app/Clones-workspace/clones-quality-agent/data/stats_viralmind/viralmind.forge_apps.json'
 
 // Owner address based on environment
-const OWNER_ADDRESS = environment === 'development' 
-  ? '0x243eDd6b1F48636568476c8167CBe63C7Fe0ac8D'
-  : '0x6E60D7b7b1587863dE6D2078C020d61F65781d7e'
+const OWNER_ADDRESS = '0x6E60D7b7b1587863dE6D2078C020d61F65781d7e'
 
 // Note: For archived factories, we don't set poolAddress or token
 
@@ -51,9 +49,6 @@ function formatSkills(skillsText) {
     .map(skill => skill.charAt(0).toUpperCase() + skill.slice(1))
 }
 
-/**
- * Transform training pool data to factory format
- */
 function transformTrainingPool(pool: any, appsMap: Map<string, any[]>) {
   const poolId = pool._id.$oid
   const factoryId = `factory_${poolId}`
@@ -61,20 +56,35 @@ function transformTrainingPool(pool: any, appsMap: Map<string, any[]>) {
   // Get associated apps for this pool
   const poolApps = appsMap.get(poolId) || []
 
-  // Transform apps to factory app format
-  const apps = poolApps.map((app: any) => ({
-    id: app._id.$oid,
-    name: app.name,
-    domain: app.domain,
-    description: app.description || '',
-    categories: app.categories || [],
-    tasks: app.tasks.map((task: any) => ({
-      id: task._id.$oid,
-      prompt: task.prompt,
-      uploadLimit: undefined,
-      rewardLimit: undefined
-    }))
-  }))
+  // Transform to tasks-centric structure
+  // For each app, create tasks with that app in apps_used
+  const tasks: any[] = []
+
+  poolApps.forEach((app: any) => {
+    const taskApp = {
+      name: app.name,
+      domain: app.domain,
+      description: app.description || ''
+    }
+
+    // Each task from the app becomes a workflow task
+    if (app.tasks && Array.isArray(app.tasks)) {
+      app.tasks.forEach((task: any) => {
+        // Generate a task name from prompt if not available
+        const taskName = task.name || task.prompt?.substring(0, 50) || app.name
+
+        tasks.push({
+          id: task._id.$oid,
+          prompt: task.prompt,
+          categories: app.categories || [],
+          task_name: taskName,
+          apps_used: [taskApp], // App is used by this task
+          uploadLimit: undefined,
+          rewardLimit: undefined
+        })
+      })
+    }
+  })
 
   return {
     _id: factoryId,
@@ -85,7 +95,7 @@ function transformTrainingPool(pool: any, appsMap: Map<string, any[]>) {
     status: FactoryStatus.archived,
     skills: formatSkills(pool.skills),
     totalEarned: Types.Decimal128.fromString('0'),
-    apps: apps,
+    tasks: tasks,
     createdAt: new Date(pool.createdAt.$date),
     updatedAt: new Date(pool.updatedAt.$date)
   }
@@ -106,7 +116,7 @@ function loadData() {
   // Create map of apps by pool_id for efficient lookup
   const appsMap = new Map()
 
-  forgeAppsData.forEach(app => {
+  forgeAppsData.forEach((app: any) => {
     const poolId = app.pool_id?.$oid
     if (poolId) {
       if (!appsMap.has(poolId)) {

--- a/src/api/forge/apps.ts
+++ b/src/api/forge/apps.ts
@@ -123,6 +123,7 @@ function buildQueryPipeline(params: TaskQueryParams): PipelineStage[] {
       categories: '$tasks.categories',
       task_name: '$tasks.task_name',
       apps_used: '$tasks.apps_used',
+      objectives: '$tasks.objectives',
       factoryId: '$_id',
       pool_id: '$_id'
     }
@@ -469,6 +470,7 @@ router.get(
         categories: taskData.categories,
         task_name: taskData.task_name,
         apps_used: taskData.apps_used,
+        objectives: taskData.objectives,
         uploadLimitReached: limitInfo.taskLimitReached,
         currentSubmissions: limitInfo.taskSubmissions,
         limitReason: limitInfo.limitReason,
@@ -553,7 +555,8 @@ router.get(
             prompt: '$tasks.prompt',
             uploadLimit: '$tasks.uploadLimit',
             rewardLimit: '$tasks.rewardLimit',
-            categories: '$tasks.categories'
+            categories: '$tasks.categories',
+            objectives: '$tasks.objectives'
           }
         },
         pool_id: { $first: '$_id' }

--- a/src/api/forge/chat.ts
+++ b/src/api/forge/chat.ts
@@ -3,9 +3,10 @@ const router: Router = express.Router()
 import express, { type Request, type Response, type Router } from 'express'
 import OpenAI from 'openai'
 import { errorHandlerAsync } from '../../middleware/errorHandler.ts'
-import { successResponse } from '../../middleware/types/errors.ts'
+import { ApiError, successResponse } from '../../middleware/types/errors.ts'
 import { validateBody } from '../../middleware/validator.ts'
 import { SYSTEM_PROMPT, TASK_SHOT_EXAMPLES } from '../../services/forge/index.ts'
+import { FactoryModel } from '../../models/Factory.ts'
 
 import { chatRequestSchema } from '../schemas/chat.ts'
 
@@ -42,55 +43,87 @@ const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY
 })
 
-// Sample few-shot conversation history
-// Add route to router
 router.post(
   '/',
   validateBody(chatRequestSchema),
   errorHandlerAsync(async (req: Request, res: Response) => {
-    const { messages, task_prompt, apps_used, app } = req.body
+    const { messages, task_prompt, apps_used, app, factory_id, task_id } = req.body
 
-    // Support both new multi-app format and legacy single-app format
     const appsToUse = apps_used || (app ? [app] : [])
 
-    // Format context message with multiple apps
+    let existingObjectives: string[] | null = null
+
+    if (factory_id && task_id) {
+      const factory = await FactoryModel.findById(factory_id)
+      if (!factory) {
+        throw ApiError.notFound('Factory not found')
+      }
+
+      const task = factory.tasks.find((t) => t.id === task_id)
+      if (!task) {
+        throw ApiError.notFound('Task not found in factory')
+      }
+
+      if (task.objectives && task.objectives.length > 0) {
+        existingObjectives = task.objectives
+      }
+    }
+
     let contextMessage = `Task: ${task_prompt}\n`
 
     if (appsToUse.length > 1) {
-      // Multi-app workflow
       const appsList = appsToUse.map((appItem: any) =>
         `${appItem.name} (${appItem.domain === 'desktop' ? 'desktop app' : `web: ${appItem.domain}`})`
       ).join(', ')
       contextMessage += `Apps: ${appsList}`
     } else if (appsToUse.length === 1) {
-      // Single app (legacy format or single-app workflow)
       const appItem = appsToUse[0]
       if (appItem.type) {
-        // Legacy format
         contextMessage += `App: ${appItem.name} (${appItem.type}${appItem.type === 'executable' ? `, Path: ${appItem.path}` : `, URL: ${appItem.url}`
           })`
       } else {
-        // New format
         contextMessage += `App: ${appItem.name} (${appItem.domain === 'desktop' ? 'desktop app' : `web: ${appItem.domain}`})`
       }
     }
 
-    // Randomly select 3 few-shot examples
+    if (existingObjectives) {
+      const appName = appsToUse.length > 0 ? appsToUse.map((a: any) => a.name).join(', ') : 'the app'
+
+      const toolCall = {
+        id: 'call_cached',
+        type: 'function' as const,
+        function: {
+          name: 'validate_task_request',
+          arguments: JSON.stringify({
+            title: task_prompt,
+            app: appName,
+            objectives: existingObjectives,
+            content: `Hi! I need help with: ${task_prompt}`
+          })
+        }
+      }
+
+      res.status(200).json(
+        successResponse({
+          role: 'assistant',
+          content: null,
+          tool_calls: [toolCall]
+        })
+      )
+      return
+    }
+
     const randomExamples = [...TASK_SHOT_EXAMPLES].sort(() => Math.random() - 0.5).slice(0, 3)
 
-    // Prepare messages for OpenAI API
     const apiMessages = [
       { role: 'system', content: SYSTEM_PROMPT },
-      // Include all three random examples
       ...randomExamples.flatMap((example) => example.conversation),
       { role: 'user', content: contextMessage },
       ...messages
     ]
 
-    // Call OpenAI API
     const response = await openai.chat.completions.create({
       model: 'gpt-4o',
-      // biome-ignore lint/suspicious/noExplicitAny: The `apiMessages` array is dynamically constructed and includes system, user, and few-shot example messages, making its type complex to align perfectly with the OpenAI SDK's expected type.
       messages: apiMessages as any,
       tools: [
         {
@@ -132,10 +165,8 @@ router.post(
 
     const assistantMessage = response.choices[0].message
 
-    // Handle tool calls if present
     if (assistantMessage.tool_calls?.[0]?.type === 'function') {
       const toolCall = assistantMessage.tool_calls[0]
-      // Add tool call to response
       res.status(200).json(
         successResponse({
           role: 'assistant',
@@ -144,7 +175,6 @@ router.post(
         })
       )
     } else {
-      // Return regular message
       res.status(200).json(
         successResponse({
           role: 'assistant',

--- a/src/api/forge/demo-files.ts
+++ b/src/api/forge/demo-files.ts
@@ -7,6 +7,7 @@ import { DemoStorageService } from '../../services/demo-storage/index.ts'
 import { errorHandlerAsync } from '../../middleware/errorHandler.ts'
 import { generalRateLimit } from '../../middleware/rateLimiter.ts'
 import { logger } from "../../services/logger.ts"
+import { WalletConnectionModel } from '../../models/Models.ts'
 
 const router = express.Router()
 
@@ -178,8 +179,14 @@ router.get('/:submissionId/verify',
  * @swagger
  * /forge/demo-files/{submissionId}/{filename}:
  *   get:
- *     summary: Download a specific demo file
- *     description: Download a file from a demonstration submission. Only the owner can access their files.
+ *     summary: Download or stream a specific demo file
+ *     description: |
+ *       Download a file from a demonstration submission. Only the owner or factory creator can access files.
+ *
+ *       For video files (recording.mp4), supports HTTP Range requests for efficient streaming:
+ *       - Send `Range: bytes=0-1023` header to request partial content
+ *       - Server responds with 206 Partial Content
+ *       - Enables video seeking, progressive loading, and bandwidth optimization
  *     tags: [Demo Files]
  *     security:
  *       - sessionAuth: []
@@ -196,27 +203,51 @@ router.get('/:submissionId/verify',
  *         schema:
  *           type: string
  *         description: The filename to download
- *         example: "meta.json"
- *       - in: query
- *         name: asBase64
+ *         example: "recording.mp4"
+ *       - in: header
+ *         name: Range
  *         required: false
  *         schema:
  *           type: string
- *           enum: ["true"]
- *         description: Return MP4 files as base64 encoded text instead of binary. Only works for recording.mp4 files.
- *         example: "true"
+ *         description: HTTP Range header for partial content requests (e.g., "bytes=0-1023")
+ *         example: "bytes=0-1048575"
  *     responses:
  *       200:
- *         description: File downloaded successfully
+ *         description: File downloaded successfully (full content)
  *         content:
  *           application/json:
  *             description: JSON files (meta.json, sft.json)
  *           video/mp4:
- *             description: Recording video files (binary)
+ *             description: Recording video files (binary stream with Accept-Ranges support)
  *           application/x-ndjson:
  *             description: Input log files (jsonl)
- *           text/plain:
- *             description: MP4 files encoded as base64 text (when asBase64=true)
+ *         headers:
+ *           Accept-Ranges:
+ *             schema:
+ *               type: string
+ *             description: Indicates server accepts Range requests (for video files)
+ *           Cache-Control:
+ *             schema:
+ *               type: string
+ *             description: Cache directives (immutable for videos)
+ *       206:
+ *         description: Partial content (Range request successful)
+ *         content:
+ *           video/mp4:
+ *             description: Partial video content
+ *         headers:
+ *           Content-Range:
+ *             schema:
+ *               type: string
+ *             description: Range of bytes returned (e.g., "bytes 0-1048575/52428800")
+ *           Content-Length:
+ *             schema:
+ *               type: integer
+ *             description: Size of partial content
+ *           Accept-Ranges:
+ *             schema:
+ *               type: string
+ *             description: Server accepts Range requests
  *       400:
  *         $ref: '#/components/responses/BadRequest'
  *       401:
@@ -227,17 +258,39 @@ router.get('/:submissionId/verify',
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/Error'
+ *       416:
+ *         description: Range Not Satisfiable (invalid range request)
  *       429:
  *         $ref: '#/components/responses/RateLimit'
  */
 // GET /api/v1/forge/demo-files/:submissionId/:filename
 router.get('/:submissionId/:filename',
   generalRateLimit, // Rate limit file downloads
-  requireWalletAddress,
   errorHandlerAsync(async (req: any, res: Response) => {
     const { submissionId, filename } = req.params
-    const { asBase64 } = req.query
-    const userAddress = req.walletAddress
+    const tokenQuery = req.query.token as string | undefined
+
+    // Try token from query param first (for media players without custom headers)
+    let userAddress: string | undefined
+    const tokenToCheck = tokenQuery || req.headers['x-connect-token']
+
+    if (!tokenToCheck) {
+      return res.status(401).json({
+        success: false,
+        error: 'Authentication required (token missing)'
+      })
+    }
+
+    // Validate connect token
+    const connection = await WalletConnectionModel.findOne({ token: tokenToCheck })
+    if (!connection || !connection.address) {
+      return res.status(401).json({
+        success: false,
+        error: 'Invalid or expired token'
+      })
+    }
+
+    userAddress = connection.address
 
     if (!submissionId || !filename) {
       return res.status(400).json({
@@ -245,11 +298,13 @@ router.get('/:submissionId/:filename',
         error: 'Submission ID and filename are required'
       })
     }
+
+    // Check user access to submission
     logger.info('Searching for submission:', submissionId)
     logger.info('User address:', userAddress)
 
     const accessCheck = await hasAccessToSubmission(submissionId, userAddress)
-    
+
     logger.info('Access check result:', {
       hasAccess: accessCheck.hasAccess,
       accessType: accessCheck.accessType,
@@ -306,21 +361,47 @@ router.get('/:submissionId/:filename',
         return 'application/octet-stream'
       }
 
-      if (asBase64 === 'true' && filename.endsWith('recording.mp4')) {
-        const fileBuffer = await demoStorageService.getDemoFile(submission.demoHash, filename)
-        const base64Data = fileBuffer.toString('base64')
-        res.setHeader('Content-Type', 'text/plain')
-        res.setHeader('Content-Length', base64Data.length)
-        res.setHeader('Content-Disposition', `inline; filename="${filename}.txt"`)
-        res.send(base64Data)
+      // Check for Range request header
+      const rangeHeader = req.headers.range
+
+      // For video files, support Range requests for efficient streaming
+      if (filename.endsWith('recording.mp4') && rangeHeader) {
+        const { stream, contentLength, contentRange, totalSize } =
+          await demoStorageService.getDemoFileStreamWithRange(
+            submission.demoHash,
+            filename,
+            rangeHeader
+          )
+
+        // Set headers for partial content response (206)
+        res.status(206) // Partial Content
+        res.setHeader('Content-Type', getContentType(filename))
+        res.setHeader('Content-Length', contentLength)
+        res.setHeader('Content-Range', contentRange || `bytes 0-${contentLength - 1}/${totalSize}`)
+        res.setHeader('Accept-Ranges', 'bytes')
+        res.setHeader('Content-Disposition', `inline; filename="${filename}"`)
+
+        // Enable caching for video chunks (helps with seeking)
+        res.setHeader('Cache-Control', 'public, max-age=31536000, immutable')
+
+        // Stream the partial content
+        stream.pipe(res)
         return
       }
 
+      // Regular streaming for non-range requests or non-video files
       const fileStream = await demoStorageService.getDemoFileStream(submission.demoHash, filename)
 
       // Set appropriate headers
       res.setHeader('Content-Type', getContentType(filename))
       res.setHeader('Content-Disposition', `inline; filename="${filename}"`)
+
+      // For video files, advertise Range support even without Range request
+      if (filename.endsWith('recording.mp4')) {
+        res.setHeader('Accept-Ranges', 'bytes')
+        // Cache video files aggressively
+        res.setHeader('Cache-Control', 'public, max-age=31536000, immutable')
+      }
 
       // Stream the file directly (no memory buffering)
       fileStream.pipe(res)

--- a/src/api/forge/factories.test.ts
+++ b/src/api/forge/factories.test.ts
@@ -157,7 +157,6 @@ describe('Forge Factories API', () => {
           decimals: 6,
           type: 'ERC20'
         },
-        // NEW: Tasks structure for testing
         tasks: [
           {
             id: 'task_1',
@@ -207,7 +206,6 @@ describe('Forge Factories API', () => {
           decimals: 18,
           type: 'ERC20'
         },
-        // NEW: Tasks structure for testing
         tasks: [
           {
             id: 'task_3',

--- a/src/api/forge/factories.ts
+++ b/src/api/forge/factories.ts
@@ -2,6 +2,7 @@ import express, { type Request, type Response, type Router } from 'express'
 import { requireWalletAddress } from '../../middleware/auth.ts'
 import { errorHandlerAsync } from '../../middleware/errorHandler.ts'
 import { ApiError, successResponse } from '../../middleware/types/errors.ts'
+import { forgeReadRateLimit } from '../../middleware/rateLimiter.ts'
 import {
   ValidationRules,
   validateBody,
@@ -62,6 +63,106 @@ const router: Router = express.Router()
 const blockchainService = new BlockchainService(process.env.RPC_URL || '')
 
 /**
+ * Helper function to get grading results for multiple factories in batch
+ */
+async function getBatchGradingResults(factoryIds: string[]) {
+  const submissions = await DemonstrationSubmission.find(
+    {
+      'meta.quest.pool_id': { $in: factoryIds },
+      status: 'completed',
+      'grade_result.score': { $exists: true, $ne: null }
+    },
+    {
+      'meta.quest.pool_id': 1,
+      'grade_result.score': 1,
+      'grade_result.confidence': 1,
+      'grade_result.outcomeAchievement': 1,
+      'grade_result.processQuality': 1,
+      'grade_result.efficiency': 1,
+      createdAt: 1,
+      _id: 1
+    }
+  )
+    .sort({ createdAt: -1 })
+    .lean()
+
+  // Group results by factory ID
+  const resultsByFactory = new Map<string, any[]>()
+
+  for (const sub of submissions) {
+    if (!sub.grade_result) continue
+
+    const factoryId = sub.meta?.quest?.pool_id
+    if (!factoryId) continue
+
+    if (!resultsByFactory.has(factoryId)) {
+      resultsByFactory.set(factoryId, [])
+    }
+
+    resultsByFactory.get(factoryId)!.push({
+      submissionId: sub._id,
+      createdAt: sub.createdAt,
+      score: sub.grade_result.score,
+      confidence: sub.grade_result.confidence,
+      outcomeAchievement: sub.grade_result.outcomeAchievement,
+      processQuality: sub.grade_result.processQuality,
+      efficiency: sub.grade_result.efficiency
+    })
+  }
+
+  return resultsByFactory
+}
+
+/**
+ * Helper function to enrich factories with demonstrations, balances, and grading results
+ */
+async function enrichFactoriesWithMetadata(
+  factories: any[]
+): Promise<FactoryWithDemonstrations[]> {
+  const factoryIds = factories.map(f => (f as unknown as IFactoryDocument)._id.toString())
+
+  // Fetch all metadata in parallel
+  const [demonstrationCounts, balancesArray, gradingResultsMap] = await Promise.all([
+    getFactoriesDemonstrationCounts(factoryIds),
+    // Fetch balances for all factories in parallel (only for factories with poolAddress and token)
+    Promise.all(factories.map(async factory => {
+      const factoryDocument = factory as unknown as IFactoryDocument
+      if (factoryDocument.token && factoryDocument.poolAddress) {
+        try {
+          const balance = await blockchainService.getTokenBalance(
+            factoryDocument.token.address,
+            factoryDocument.poolAddress
+          )
+          return { id: factoryDocument._id.toString(), balance }
+        } catch (error) {
+          logger.error(`Failed to fetch balance for factory ${factoryDocument._id}:`, error)
+          return { id: factoryDocument._id.toString(), balance: 0 }
+        }
+      }
+      return { id: factoryDocument._id.toString(), balance: 0 }
+    })),
+    getBatchGradingResults(factoryIds)
+  ])
+
+  const balancesMap = new Map(balancesArray.map(b => [b.id, b.balance]))
+
+  return factories.map(factory => {
+    const factoryDocument = factory as unknown as IFactoryDocument
+    const factoryJson = factoryDocument.toJSON() as Omit<Factory, 'totalEarned'> & { totalEarned: unknown }
+    const id = factoryDocument._id.toString()
+
+    return {
+      ...factoryJson,
+      id,
+      totalEarned: coerceDecimalValue(factoryJson.totalEarned),
+      demonstrations: demonstrationCounts.get(id) ?? 0,
+      balance: balancesMap.get(id) ?? 0,
+      gradingResults: gradingResultsMap.get(id) ?? []
+    }
+  })
+}
+
+/**
  * @swagger
  * tags:
  *   name: Factories
@@ -104,6 +205,9 @@ router.get(
     res.status(200).json(successResponse(tokens))
   })
 )
+
+// Apply relaxed rate limiting to all factory read routes
+router.use(forgeReadRateLimit)
 
 /**
  * @swagger
@@ -222,22 +326,8 @@ router.post(
 
     const total = await FactoryModel.countDocuments(query)
 
-    // Add demonstration counts to factories
-    const factoryIds = factories.map(f => (f as unknown as IFactoryDocument)._id.toString())
-    const demonstrationCounts = await getFactoriesDemonstrationCounts(factoryIds)
-
-    const factoriesWithDemonstrations: FactoryWithDemonstrations[] = factories.map(factory => {
-      const factoryDocument = factory as unknown as IFactoryDocument
-      const factoryJson = factoryDocument.toJSON() as Omit<Factory, 'totalEarned'> & { totalEarned: unknown }
-      const id = factoryDocument._id.toString()
-
-      return {
-        ...factoryJson,
-        id,
-        totalEarned: coerceDecimalValue(factoryJson.totalEarned),
-        demonstrations: demonstrationCounts.get(id) ?? 0
-      }
-    })
+    // Add demonstration counts and balances to factories
+    const factoriesWithDemonstrations = await enrichFactoriesWithMetadata(factories)
 
     const result: FactorySearchResult = {
       factories: factoriesWithDemonstrations,
@@ -300,22 +390,8 @@ router.get(
 
     const total = await FactoryModel.countDocuments(query)
 
-    // Add demonstration counts to factories
-    const factoryIds = factories.map(f => (f as unknown as IFactoryDocument)._id.toString())
-    const demonstrationCounts = await getFactoriesDemonstrationCounts(factoryIds)
-
-    const factoriesWithDemonstrations: FactoryWithDemonstrations[] = factories.map(factory => {
-      const factoryDocument = factory as unknown as IFactoryDocument
-      const factoryJson = factoryDocument.toJSON() as Omit<Factory, 'totalEarned'> & { totalEarned: unknown }
-      const id = factoryDocument._id.toString()
-
-      return {
-        ...factoryJson,
-        id,
-        totalEarned: coerceDecimalValue(factoryJson.totalEarned),
-        demonstrations: demonstrationCounts.get(id) ?? 0
-      }
-    })
+    // Add demonstration counts and balances to factories
+    const factoriesWithDemonstrations = await enrichFactoriesWithMetadata(factories)
 
     const result: FactorySearchResult = {
       factories: factoriesWithDemonstrations,

--- a/src/api/forge/grading.ts
+++ b/src/api/forge/grading.ts
@@ -1,0 +1,313 @@
+/**
+ * Grading endpoints for demonstration submissions
+ * These endpoints are used by migration scripts and admin tools
+ */
+
+import { Router } from 'express'
+import { promises as fs } from 'node:fs'
+import * as path from 'node:path'
+import { DemonstrationSubmission } from '../../models/DemonstrationSubmission.ts'
+import { runCQAGrading, prepareDemoForGrading } from '../../services/grading/cqaGradingService.ts'
+import { DemoStorageService } from '../../services/demo-storage/index.ts'
+import { ObjectStorageService } from '../../services/storage/index.ts'
+import { logger } from '../../services/logger.ts'
+
+const router = Router()
+
+// Initialize storage service
+let demoStorageService: DemoStorageService | null = null
+
+function getDemoStorageService(): DemoStorageService {
+  if (!demoStorageService) {
+    const {
+      STORAGE_ACCESS_KEY,
+      STORAGE_SECRET_KEY,
+      STORAGE_ENDPOINT,
+      STORAGE_REGION,
+      STORAGE_BUCKET
+    } = process.env
+
+    if (!STORAGE_ACCESS_KEY || !STORAGE_SECRET_KEY || !STORAGE_ENDPOINT || !STORAGE_REGION || !STORAGE_BUCKET) {
+      throw new Error('Storage service environment variables are not properly configured')
+    }
+
+    const objectStorage = new ObjectStorageService(
+      STORAGE_ACCESS_KEY,
+      STORAGE_SECRET_KEY,
+      STORAGE_ENDPOINT,
+      STORAGE_REGION,
+      STORAGE_BUCKET
+    )
+    demoStorageService = new DemoStorageService(objectStorage)
+  }
+  return demoStorageService
+}
+
+/**
+ * POST /api/v1/forge/grading/grade-submission/:submissionId
+ *
+ * Grade a demonstration submission
+ *
+ * Query parameters:
+ * - useVideoGrading: boolean (default: true)
+ * - model: string (default: from env CQA_MODEL)
+ *
+ * Returns:
+ * - gradeResult: ForgeSubmissionGradeResult
+ * - gradingMetrics: any
+ * - clampedScore: number
+ */
+router.post('/grade-submission/:submissionId', async (req, res) => {
+  const { submissionId } = req.params
+  const useVideoGrading = req.query.useVideoGrading !== 'false'
+  const model = (req.query.model as string) || process.env.CQA_MODEL
+
+  logger.info('Admin grading request', { submissionId, useVideoGrading, model })
+
+  try {
+    // Find submission
+    const submission = await DemonstrationSubmission.findById(submissionId)
+    if (!submission) {
+      return res.status(404).json({ error: 'Submission not found' })
+    }
+
+    // Check if demoHash exists
+    if (!submission.demoHash) {
+      return res.status(400).json({ error: 'Submission has no demoHash' })
+    }
+
+    // Check if already graded
+    if (submission.grade_result && submission.grade_result.score !== null && submission.grade_result.score !== undefined) {
+      logger.info('Submission already graded', { submissionId, score: submission.grade_result.score })
+      return res.json({
+        message: 'Submission already graded',
+        gradeResult: submission.grade_result,
+        gradingMetrics: submission.grading_metrics,
+        clampedScore: submission.clampedScore,
+        alreadyGraded: true
+      })
+    }
+
+    // Create temporary directory for grading
+    const tempDir = path.join(process.cwd(), 'temp', 'grading', submissionId)
+
+    try {
+      await fs.mkdir(tempDir, { recursive: true })
+      logger.info('Created temp directory', { tempDir })
+
+      // Download demo files
+      logger.info('Downloading demo files', { demoHash: submission.demoHash })
+      const storage = getDemoStorageService()
+      await prepareDemoForGrading(submission.demoHash, tempDir, storage)
+
+      // Run CQA grading
+      logger.info('Running CQA grading', { tempDir })
+      const { gradeResult, gradingMetrics } = await runCQAGrading(tempDir, {
+        useVideoGrading,
+        model,
+        cleanupOnSuccess: false,
+        cleanupOnError: false
+      })
+
+      // Calculate clamped score
+      const clampedScore = Math.max(0, Math.min(100, gradeResult.score))
+
+      // Update database
+      const updateData: any = {
+        grade_result: gradeResult,
+        clampedScore: clampedScore
+      }
+
+      if (gradingMetrics) {
+        updateData.grading_metrics = gradingMetrics
+      }
+
+      if (model) {
+        updateData.cqaModel = model
+      }
+
+      await DemonstrationSubmission.findByIdAndUpdate(
+        submission._id,
+        { $set: updateData }
+      )
+
+      logger.info('Updated submission with grade result', {
+        submissionId,
+        score: gradeResult.score,
+        clampedScore
+      })
+
+      // Clean up temp directory
+      try {
+        await fs.rm(tempDir, { recursive: true, force: true })
+        logger.info('Cleaned up temp directory', { tempDir })
+      } catch (cleanupError) {
+        logger.warn('Failed to cleanup temp directory', { error: cleanupError })
+      }
+
+      return res.json({
+        message: 'Submission graded successfully',
+        gradeResult,
+        gradingMetrics,
+        clampedScore,
+        alreadyGraded: false
+      })
+
+    } catch (error) {
+      // Clean up temp directory on error
+      try {
+        await fs.rm(tempDir, { recursive: true, force: true })
+        logger.info('Cleaned up temp directory after error', { tempDir })
+      } catch (cleanupError) {
+        logger.warn('Failed to cleanup temp directory', { error: cleanupError })
+      }
+
+      throw error
+    }
+
+  } catch (error) {
+    logger.error('Failed to grade submission', { submissionId, error })
+    return res.status(500).json({
+      error: 'Failed to grade submission',
+      message: (error as Error).message
+    })
+  }
+})
+
+/**
+ * POST /api/v1/forge/grading/batch-grade
+ *
+ * Grade multiple submissions in batch
+ *
+ * Body:
+ * - submissionIds: string[]
+ * - useVideoGrading: boolean (default: true)
+ * - model: string (default: from env CQA_MODEL)
+ *
+ * Returns:
+ * - results: array of grading results
+ * - summary: { total, successful, failed, skipped }
+ */
+router.post('/batch-grade', async (req, res) => {
+  const { submissionIds, useVideoGrading = true, model } = req.body
+
+  if (!Array.isArray(submissionIds) || submissionIds.length === 0) {
+    return res.status(400).json({ error: 'submissionIds must be a non-empty array' })
+  }
+
+  logger.info('Batch grading request', { count: submissionIds.length, useVideoGrading, model })
+
+  const results = []
+  let successful = 0
+  let failed = 0
+  let skipped = 0
+
+  for (const submissionId of submissionIds) {
+    try {
+      // Make internal request to grade-submission endpoint
+      const submission = await DemonstrationSubmission.findById(submissionId)
+
+      if (!submission) {
+        results.push({ submissionId, status: 'not_found', error: 'Submission not found' })
+        failed++
+        continue
+      }
+
+      if (!submission.demoHash) {
+        results.push({ submissionId, status: 'no_demohash', error: 'No demoHash' })
+        skipped++
+        continue
+      }
+
+      if (submission.grade_result && submission.grade_result.score !== null) {
+        results.push({
+          submissionId,
+          status: 'already_graded',
+          score: submission.grade_result.score
+        })
+        skipped++
+        continue
+      }
+
+      // Grade submission
+      const tempDir = path.join(process.cwd(), 'temp', 'grading', submissionId)
+
+      try {
+        await fs.mkdir(tempDir, { recursive: true })
+        const storage = getDemoStorageService()
+        await prepareDemoForGrading(submission.demoHash, tempDir, storage)
+
+        const { gradeResult, gradingMetrics } = await runCQAGrading(tempDir, {
+          useVideoGrading,
+          model: model || process.env.CQA_MODEL,
+          cleanupOnSuccess: false,
+          cleanupOnError: false
+        })
+
+        const clampedScore = Math.max(0, Math.min(100, gradeResult.score))
+
+        const updateData: any = {
+          grade_result: gradeResult,
+          clampedScore: clampedScore
+        }
+
+        if (gradingMetrics) {
+          updateData.grading_metrics = gradingMetrics
+        }
+
+        if (model || process.env.CQA_MODEL) {
+          updateData.cqaModel = model || process.env.CQA_MODEL
+        }
+
+        await DemonstrationSubmission.findByIdAndUpdate(
+          submission._id,
+          { $set: updateData }
+        )
+
+        // Clean up
+        try {
+          await fs.rm(tempDir, { recursive: true, force: true })
+        } catch {}
+
+        results.push({
+          submissionId,
+          status: 'success',
+          score: gradeResult.score,
+          clampedScore
+        })
+        successful++
+
+      } catch (error) {
+        // Clean up on error
+        try {
+          await fs.rm(tempDir, { recursive: true, force: true })
+        } catch {}
+
+        throw error
+      }
+
+    } catch (error) {
+      logger.error('Failed to grade submission in batch', { submissionId, error })
+      results.push({
+        submissionId,
+        status: 'failed',
+        error: (error as Error).message
+      })
+      failed++
+    }
+  }
+
+  logger.info('Batch grading completed', { total: submissionIds.length, successful, failed, skipped })
+
+  return res.json({
+    results,
+    summary: {
+      total: submissionIds.length,
+      successful,
+      failed,
+      skipped
+    }
+  })
+})
+
+export default router

--- a/src/api/forge/grading.ts
+++ b/src/api/forge/grading.ts
@@ -1,6 +1,11 @@
 /**
  * Grading endpoints for demonstration submissions
  * These endpoints are used by migration scripts and admin tools
+ *
+ * SECURITY: These endpoints are protected by admin authentication only.
+ * Rate limiting is NOT applied because these endpoints are designed for batch operations
+ * by migration scripts that may need to process hundreds of submissions.
+ * Access control via x-admin-token header is sufficient protection.
  */
 
 import { Router } from 'express'
@@ -11,8 +16,12 @@ import { runCQAGrading, prepareDemoForGrading } from '../../services/grading/cqa
 import { DemoStorageService } from '../../services/demo-storage/index.ts'
 import { ObjectStorageService } from '../../services/storage/index.ts'
 import { logger } from '../../services/logger.ts'
+import { requireAdminAuth } from '../../middleware/auth.ts'
 
 const router = Router()
+
+// Apply admin authentication to all grading endpoints
+router.use(requireAdminAuth)
 
 // Initialize storage service
 let demoStorageService: DemoStorageService | null = null
@@ -89,7 +98,8 @@ router.post('/grade-submission/:submissionId', async (req, res) => {
     }
 
     // Create temporary directory for grading
-    const tempDir = path.join(process.cwd(), 'temp', 'grading', submissionId)
+    const sanitizedId = submissionId.replace(/[^a-zA-Z0-9_-]/g, '')
+    const tempDir = path.join(process.cwd(), 'temp', 'grading', sanitizedId)
 
     try {
       await fs.mkdir(tempDir, { recursive: true })
@@ -180,7 +190,7 @@ router.post('/grade-submission/:submissionId', async (req, res) => {
  * Grade multiple submissions in batch
  *
  * Body:
- * - submissionIds: string[]
+ * - submissionIds: string[] (max 500 per request)
  * - useVideoGrading: boolean (default: true)
  * - model: string (default: from env CQA_MODEL)
  *
@@ -193,6 +203,16 @@ router.post('/batch-grade', async (req, res) => {
 
   if (!Array.isArray(submissionIds) || submissionIds.length === 0) {
     return res.status(400).json({ error: 'submissionIds must be a non-empty array' })
+  }
+
+  // Reasonable limit to prevent accidental abuse even with admin auth
+  const MAX_BATCH_SIZE = 500
+  if (submissionIds.length > MAX_BATCH_SIZE) {
+    return res.status(400).json({
+      error: `Batch size exceeds maximum allowed (${MAX_BATCH_SIZE}). Please split into smaller batches.`,
+      maxBatchSize: MAX_BATCH_SIZE,
+      receivedSize: submissionIds.length
+    })
   }
 
   logger.info('Batch grading request', { count: submissionIds.length, useVideoGrading, model })
@@ -267,7 +287,7 @@ router.post('/batch-grade', async (req, res) => {
         // Clean up
         try {
           await fs.rm(tempDir, { recursive: true, force: true })
-        } catch {}
+        } catch { }
 
         results.push({
           submissionId,
@@ -281,7 +301,7 @@ router.post('/batch-grade', async (req, res) => {
         // Clean up on error
         try {
           await fs.rm(tempDir, { recursive: true, force: true })
-        } catch {}
+        } catch { }
 
         throw error
       }

--- a/src/api/schemas/chat.ts
+++ b/src/api/schemas/chat.ts
@@ -13,9 +13,16 @@ export const chatRequestSchema: ValidationSchema = {
     required: false,
     rules: [ValidationRules.isArray(), ValidationRules.arrayMinLength(1)]
   },
-  // Backward compatibility - keep app for single-app workflows
   app: {
     required: false,
     rules: [ValidationRules.isObject()]
+  },
+  factory_id: {
+    required: false,
+    rules: [ValidationRules.isString()]
+  },
+  task_id: {
+    required: false,
+    rules: [ValidationRules.isString()]
   }
 }

--- a/src/middleware/rateLimiter.ts
+++ b/src/middleware/rateLimiter.ts
@@ -63,3 +63,35 @@ export const forgeReadRateLimit = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
 });
+
+/**
+ * Strict rate limiter for expensive grading operations
+ * CQA grading involves LLM API calls and significant compute resources
+ */
+export const gradingRateLimit = rateLimit({
+  windowMs: 60 * 60 * 1000, // 1 hour
+  max: 10, // 10 grading requests per hour per IP
+  message: {
+    success: false,
+    error: 'Too many grading requests. Grading operations are resource-intensive. Please try again later.',
+    code: 'GRADING_RATE_LIMIT_EXCEEDED'
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+/**
+ * Very strict rate limiter for batch grading operations
+ * Batch grading can process multiple submissions and is extremely expensive
+ */
+export const batchGradingRateLimit = rateLimit({
+  windowMs: 60 * 60 * 1000, // 1 hour
+  max: 3, // 3 batch operations per hour per IP
+  message: {
+    success: false,
+    error: 'Too many batch grading requests. This operation is extremely resource-intensive. Please try again later.',
+    code: 'BATCH_GRADING_RATE_LIMIT_EXCEEDED'
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+});

--- a/src/middleware/rateLimiter.ts
+++ b/src/middleware/rateLimiter.ts
@@ -47,3 +47,19 @@ export const strictRateLimit = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
 });
+
+/**
+ * Relaxed rate limiter for forge/factory read operations
+ * Higher limits to support loading multiple factories and their metadata
+ */
+export const forgeReadRateLimit = rateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 300, // 300 requests per minute per IP
+  message: {
+    success: false,
+    error: 'Too many forge requests. Please slow down.',
+    code: 'RATE_LIMIT_EXCEEDED'
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+});

--- a/src/middleware/secureSession.ts
+++ b/src/middleware/secureSession.ts
@@ -128,6 +128,7 @@ export function configureSecureSession(app: Application): void {
     '/api/v1/withdrawal/reputation',   // Creator reputation queries (GET)
     '/api/v1/forge/recordings', // Recordings (POST)
     '/api/v1/forge/recordings/health', // Recordings health (GET)
+    '/api/v1/forge/grading', // Forge grading endpoints
   ];
 
   // Apply CSRF protection to all routes except bootstrap endpoints

--- a/src/models/Factory.ts
+++ b/src/models/Factory.ts
@@ -159,7 +159,13 @@ const workflowTaskSchema = new Schema<WorkflowTask>(
       set: function (value: any) {
         return value === null || value === undefined ? value : Types.Decimal128.fromString(value.toString())
       }
-    }
+    },
+    objectives: [
+      {
+        type: String,
+        maxlength: 500
+      }
+    ]
   },
   { _id: false }
 )

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import helmet from 'helmet'
 import mongoose from 'mongoose'
 import swaggerUi from 'swagger-ui-express'
 import swaggerSpec from '../swagger.ts'
+import forgeGradingApi from './api/forge/grading.ts'
 import { demonstrationApi } from './api/demonstration.ts'
 import { forgeApi } from './api/forge/index.ts'
 import { referralApi } from './api/referral.ts'
@@ -114,6 +115,9 @@ app.use('/api/v1/wallet', walletApi)
 app.use('/api/v1/referral', referralApi)
 app.use('/api/v1/transaction', transactionApi)
 app.use('/api/v1/withdrawal', withdrawalApi)
+
+// Grading endpoints
+app.use('/api/v1/forge/grading', forgeGradingApi)
 
 // Swagger API documentation
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec))

--- a/src/services/demo-storage/index.ts
+++ b/src/services/demo-storage/index.ts
@@ -100,29 +100,82 @@ export class DemoStorageService {
 
   /**
    * Retrieve a file from a demonstration
+   * Tries v1 first (current), then fallback to v0 (legacy migrated data)
    */
   async getDemoFile(demoHash: string, filename: string): Promise<Buffer> {
-    const filePath = getDemoStoragePath(demoHash, filename)
-
+    // Try v1 first (current production)
     try {
-      return await this.objectStorage.getItem({ name: filePath })
-    } catch (error) {
-      logger.error(`[DemoStorage] Failed to get ${filename} for demo ${demoHash}: ${error}`)
-      throw new Error(`Demo file not found: ${filename}`)
+      const filePathV1 = getDemoStoragePath(demoHash, filename, 'v1')
+      return await this.objectStorage.getItem({ name: filePathV1 })
+    } catch (errorV1) {
+      // Fallback to v0 (legacy migrated data)
+      try {
+        const filePathV0 = getDemoStoragePath(demoHash, filename, 'v0')
+        logger.info(`[DemoStorage] File not found in v1, trying v0 fallback: ${filename}`)
+        return await this.objectStorage.getItem({ name: filePathV0 })
+      } catch (errorV0) {
+        logger.error(`[DemoStorage] Failed to get ${filename} for demo ${demoHash} in both v1 and v0: ${errorV0}`)
+        throw new Error(`Demo file not found: ${filename}`)
+      }
     }
   }
 
   /**
    * Stream a file from a demonstration
+   * Tries v1 first (current), then fallback to v0 (legacy migrated data)
    */
   async getDemoFileStream(demoHash: string, filename: string): Promise<NodeJS.ReadableStream> {
-    const filePath = getDemoStoragePath(demoHash, filename)
-
+    // Try v1 first (current production)
     try {
-      return await this.objectStorage.getItemStream({ name: filePath })
-    } catch (error) {
-      logger.error(`[DemoStorage] Failed to stream ${filename} for demo ${demoHash}: ${error}`)
-      throw new Error(`Demo file not found: ${filename}`)
+      const filePathV1 = getDemoStoragePath(demoHash, filename, 'v1')
+      return await this.objectStorage.getItemStream({ name: filePathV1 })
+    } catch (errorV1) {
+      // Fallback to v0 (legacy migrated data)
+      try {
+        const filePathV0 = getDemoStoragePath(demoHash, filename, 'v0')
+        logger.info(`[DemoStorage] File not found in v1, trying v0 fallback for stream: ${filename}`)
+        return await this.objectStorage.getItemStream({ name: filePathV0 })
+      } catch (errorV0) {
+        logger.error(`[DemoStorage] Failed to stream ${filename} for demo ${demoHash} in both v1 and v0: ${errorV0}`)
+        throw new Error(`Demo file not found: ${filename}`)
+      }
+    }
+  }
+
+  /**
+   * Stream a file from a demonstration with Range request support
+   * Tries v1 first (current), then fallback to v0 (legacy migrated data)
+   */
+  async getDemoFileStreamWithRange(
+    demoHash: string,
+    filename: string,
+    range?: string
+  ): Promise<{
+    stream: NodeJS.ReadableStream
+    contentLength: number
+    contentRange?: string
+    totalSize: number
+  }> {
+    // Try v1 first (current production)
+    try {
+      const filePathV1 = getDemoStoragePath(demoHash, filename, 'v1')
+      return await this.objectStorage.getItemStreamWithRange({
+        name: filePathV1,
+        range
+      })
+    } catch (errorV1) {
+      // Fallback to v0 (legacy migrated data)
+      try {
+        const filePathV0 = getDemoStoragePath(demoHash, filename, 'v0')
+        logger.info(`[DemoStorage] File not found in v1, trying v0 fallback for range stream: ${filename}`)
+        return await this.objectStorage.getItemStreamWithRange({
+          name: filePathV0,
+          range
+        })
+      } catch (errorV0) {
+        logger.error(`[DemoStorage] Failed to stream ${filename} with range for demo ${demoHash} in both v1 and v0: ${errorV0}`)
+        throw new Error(`Demo file not found: ${filename}`)
+      }
     }
   }
 
@@ -180,15 +233,25 @@ export class DemoStorageService {
 
   /**
    * Get demonstration integrity information
+   * Tries v1 first (current), then fallback to v0 (legacy migrated data)
    */
   async getDemoIntegrity(demoHash: string): Promise<DemoIntegrity | null> {
+    // Try v1 first (current production)
     try {
-      const integrityPath = getDemoStoragePath(demoHash, 'checksums.json')
-      const integrityBuffer = await this.objectStorage.getItem({ name: integrityPath })
+      const integrityPathV1 = getDemoStoragePath(demoHash, 'checksums.json', 'v1')
+      const integrityBuffer = await this.objectStorage.getItem({ name: integrityPathV1 })
       return JSON.parse(integrityBuffer.toString())
-    } catch (error) {
-      logger.error(`[DemoStorage] Failed to get integrity for demo ${demoHash}: ${error}`)
-      return null
+    } catch (errorV1) {
+      // Fallback to v0 (legacy migrated data)
+      try {
+        const integrityPathV0 = getDemoStoragePath(demoHash, 'checksums.json', 'v0')
+        logger.info(`[DemoStorage] Integrity not found in v1, trying v0 fallback`)
+        const integrityBuffer = await this.objectStorage.getItem({ name: integrityPathV0 })
+        return JSON.parse(integrityBuffer.toString())
+      } catch (errorV0) {
+        logger.error(`[DemoStorage] Failed to get integrity for demo ${demoHash} in both v1 and v0: ${errorV0}`)
+        return null
+      }
     }
   }
 

--- a/src/services/factory/factoryDatabaseService.ts
+++ b/src/services/factory/factoryDatabaseService.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from 'node:crypto'
 import OpenAI from 'openai'
 import { FactoryModel } from '../../models/Factory.ts'
-import type { FactoryApp } from '../../types/factory.ts'
-import { APP_TASK_GENERATION_PROMPT } from '../forge/index.ts'
+import type { FactoryApp, TaskApp, WorkflowTask } from '../../types/factory.ts'
+import { APP_TASK_GENERATION_PROMPT, SYSTEM_PROMPT, TASK_SHOT_EXAMPLES } from '../forge/index.ts'
 import { logger } from "../logger.ts"
 
 // Configure OpenAI
@@ -12,6 +12,88 @@ const openai = new OpenAI({
 
 // Track active generations to prevent duplicates
 const activeGenerations = new Map<string, Promise<void>>()
+
+/**
+ * Generate objectives for a specific task using OpenAI
+ */
+export async function generateObjectivesForTask(
+  taskPrompt: string,
+  appsUsed: TaskApp[]
+): Promise<string[]> {
+  try {
+    let contextMessage = `Task: ${taskPrompt}\n`
+
+    if (appsUsed.length > 1) {
+      const appsList = appsUsed
+        .map((app) => `${app.name} (${app.domain === 'desktop' ? 'desktop app' : `web: ${app.domain}`})`)
+        .join(', ')
+      contextMessage += `Apps: ${appsList}`
+    } else if (appsUsed.length === 1) {
+      const app = appsUsed[0]
+      contextMessage += `App: ${app.name} (${app.domain === 'desktop' ? 'desktop app' : `web: ${app.domain}`})`
+    }
+
+    const randomExamples = [...TASK_SHOT_EXAMPLES].sort(() => Math.random() - 0.5).slice(0, 3)
+
+    const apiMessages = [
+      { role: 'system', content: SYSTEM_PROMPT },
+      ...randomExamples.flatMap((example) => example.conversation),
+      { role: 'user', content: contextMessage }
+    ]
+
+    const response = await openai.chat.completions.create({
+      model: 'gpt-4o',
+      messages: apiMessages as any,
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'validate_task_request',
+            description: "Validate if the user's task request is appropriate and can be assisted with",
+            parameters: {
+              type: 'object',
+              required: ['title', 'app', 'objectives', 'content'],
+              properties: {
+                title: {
+                  type: 'string',
+                  description: 'Brief title for the task'
+                },
+                app: {
+                  type: 'string',
+                  description: 'Name of the app being used'
+                },
+                objectives: {
+                  type: 'array',
+                  description: `List of around ${appsUsed.length * 2 + 2} objectives to complete this ${appsUsed.length > 1 ? 'multi-app workflow' : 'single-app'} task. For multi-app workflows, include objectives for navigating between applications, data transfer, and context switching. Each app should have at least 2-3 objectives. Wrap app names in <app> tags. Stop at checkout for purchases.`,
+                  items: {
+                    type: 'string'
+                  }
+                },
+                content: {
+                  type: 'string',
+                  description: "The assistant's message to the user"
+                }
+              }
+            }
+          }
+        }
+      ]
+    })
+
+    const assistantMessage = response.choices[0].message
+
+    if (assistantMessage.tool_calls?.[0]?.type === 'function') {
+      const toolCall = assistantMessage.tool_calls[0]
+      const args = JSON.parse(toolCall.function.arguments)
+      return args.objectives || []
+    }
+
+    return []
+  } catch (error) {
+    logger.error('Error generating objectives:', error)
+    return []
+  }
+}
 
 /**
  * Generate apps for a factory using OpenAI
@@ -108,14 +190,18 @@ export async function createFactory(
   token: any,
   referrerAddress?: string
 ): Promise<any> {
-  // Create factory document
   const factoryId = `factory_${poolAddress}`
 
-  // Generate IDs for tasks
-  const tasksWithIds = tasks.map(task => ({
-    ...task,
-    id: randomUUID()
-  }))
+  const tasksWithIdsAndObjectives = await Promise.all(
+    tasks.map(async (task) => {
+      const objectives = await generateObjectivesForTask(task.prompt, task.apps_used || [])
+      return {
+        ...task,
+        id: randomUUID(),
+        objectives
+      }
+    })
+  )
 
   const factory = new FactoryModel({
     _id: factoryId,
@@ -123,11 +209,11 @@ export async function createFactory(
     name,
     description: `Factory for ${name}`,
     ownerAddress: creatorAddress,
-    referrerAddress, // Capture referrer at creation time
+    referrerAddress,
     status: 'paused',
     skills,
     token,
-    tasks: tasksWithIds,
+    tasks: tasksWithIdsAndObjectives,
     createdAt: new Date(),
     updatedAt: new Date()
   })

--- a/src/services/forge/processing.ts
+++ b/src/services/forge/processing.ts
@@ -27,6 +27,7 @@ import { createReferralLookupService } from '../referral/referralLookupService.t
 import { logger } from "../logger.ts"
 import { DemoStorageService } from '../demo-storage/index.ts'
 import { ObjectStorageService } from '../storage/index.ts'
+import { runCQAGrading } from '../grading/cqaGradingService.ts'
 
 // Initialize demo storage service
 let demoStorageService: DemoStorageService | null = null
@@ -164,106 +165,13 @@ export async function processNextInQueue() {
       const files = await fs.readdir(extractDir)
       logger.info('Directory contents:', files)
 
-      await new Promise<void>((resolve, reject) => {
-        const absoluteExtractDir = path.resolve(extractDir)
-        const args = ['-f', 'desktop', '-i', absoluteExtractDir, '--grade']
-
-        // Enable video mode by default (unless explicitly disabled)
-        const useVideoGrading = process.env.USE_VIDEO_GRADING !== 'false';
-
-        if (useVideoGrading) {
-          args.push('--video-mode')
-          logger.info('Video grading mode enabled (default)')
-        }
-
-        if (process.env.CQA_MODEL) {
-          args.push('--model', process.env.CQA_MODEL)
-        }
-
-        const pipeline = spawn(process.env.CQA_PATH, args, {
-          cwd: '/app/cqa', // Run CQA from the directory with node_modules
-          env: { ...process.env } // Explicitly pass all environment variables including API keys
-        })
-
-        let stdout = ''
-        let stderr = ''
-        let stdoutLineBuffer = ''
-        let stderrLineBuffer = ''
-
-        pipeline.stdout.on('data', (data) => {
-          stdout += data
-          stdoutLineBuffer += data.toString()
-
-          // Log complete lines as they come
-          const lines = stdoutLineBuffer.split('\n')
-          stdoutLineBuffer = lines.pop() || '' // Keep incomplete line in buffer
-
-          lines.forEach(line => {
-            if (line.trim()) {
-              logger.info({ cqaOutput: 'stdout', line }, 'CQA stdout')
-            }
-          })
-        })
-
-        pipeline.stderr.on('data', (data) => {
-          stderr += data
-          stderrLineBuffer += data.toString()
-
-          // Log complete lines as they come
-          const lines = stderrLineBuffer.split('\n')
-          stderrLineBuffer = lines.pop() || '' // Keep incomplete line in buffer
-
-          lines.forEach(line => {
-            if (line.trim()) {
-              logger.warn({ cqaOutput: 'stderr', line }, 'CQA stderr')
-            }
-          })
-        })
-
-        pipeline.on('close', (code: number) => {
-          // Log any remaining buffer content
-          if (stdoutLineBuffer.trim()) {
-            logger.info({ cqaOutput: 'stdout', line: stdoutLineBuffer.trim() }, 'CQA stdout (final)')
-          }
-          if (stderrLineBuffer.trim()) {
-            logger.warn({ cqaOutput: 'stderr', line: stderrLineBuffer.trim() }, 'CQA stderr (final)')
-          }
-
-          if (code === 0) {
-            logger.info({ exitCode: code, stdoutLength: stdout.length, stderrLength: stderr.length }, 'CQA process completed successfully')
-            resolve()
-          } else {
-            logger.error({
-              exitCode: code,
-              fullStdout: stdout,
-              fullStderr: stderr
-            }, 'CQA process failed')
-            reject(new Error(`Clones Quality Agent failed:\nstdout: ${stdout}\nstderr: ${stderr}`))
-          }
-        })
-
-        pipeline.on('error', (err) => {
-          logger.error('Clones Quality Agent spawn error:', err)
-          reject(err)
-        })
+      // Run CQA grading using the shared service
+      const { gradeResult, gradingMetrics: metricsResult } = await runCQAGrading(extractDir, {
+        useVideoGrading: process.env.USE_VIDEO_GRADING !== 'false',
+        model: process.env.CQA_MODEL,
+        cleanupOnSuccess: false,
+        cleanupOnError: false
       })
-
-      // Check if scores.json exists
-      const scoresPath = path.join(extractDir, 'scores.json')
-      try {
-        await fs.access(scoresPath)
-        logger.info('scores.json exists')
-      } catch (error) {
-        logger.error('scores.json not found:', error)
-        throw new Error('scores.json not found after Clones Quality Agent run')
-      }
-
-      // Read and parse scores.json
-      logger.info('Reading scores.json')
-      const scoresContent = await fs.readFile(scoresPath, 'utf8')
-      logger.info('scores.json content:', scoresContent)
-      const gradeResult: ForgeSubmissionGradeResult = JSON.parse(scoresContent)
-      logger.info('Parsed grade result:', gradeResult)
 
       // ENRICHMENT: If video analysis is present, inject into sft.json
       if (gradeResult.programmaticResults?.videoAnalysis && Array.isArray(gradeResult.programmaticResults.videoAnalysis)) {
@@ -325,18 +233,6 @@ export async function processNextInQueue() {
         }
       }
 
-      // Read and parse metrics.json
-      const metricsPath = path.join(extractDir, 'metrics.json')
-      let metricsResult = null
-      try {
-        await fs.access(metricsPath)
-        logger.info('metrics.json exists')
-        const metricsContent = await fs.readFile(metricsPath, 'utf8')
-        metricsResult = JSON.parse(metricsContent)
-        logger.info('Parsed metrics result:', metricsResult)
-      } catch (_error) {
-        logger.info('metrics.json not found or could not be parsed, continuing without metrics.')
-      }
 
       // Get factory details and calculate reward
       let reward

--- a/src/services/grading/README.md
+++ b/src/services/grading/README.md
@@ -1,0 +1,79 @@
+# CQA Grading Service
+
+This service provides a unified interface for running Clones Quality Agent (CQA) grading across different environments.
+
+## Features
+
+- **Auto-detection of CQA**: Automatically detects whether to use local TypeScript source (with bun) or compiled binary
+- **Environment-agnostic**: Works in development (macOS), Docker, and production
+- **Consistent configuration**: Shares environment variables and configuration with the rest of the backend
+- **Proper logging**: Uses the backend's logger for consistent log formatting
+- **Error handling**: Comprehensive error handling with cleanup options
+
+## Usage
+
+### Basic Grading
+
+```typescript
+import { runCQAGrading } from '../services/grading/cqaGradingService'
+
+const { gradeResult, gradingMetrics } = await runCQAGrading('/path/to/demo/directory', {
+  useVideoGrading: true,
+  model: 'gemini-2.0-flash',
+  cleanupOnSuccess: false,
+  cleanupOnError: true
+})
+
+console.log(`Score: ${gradeResult.score}`)
+```
+
+### Preparing Demo for Grading
+
+```typescript
+import { prepareDemoForGrading } from '../services/grading/cqaGradingService'
+import { DemoStorageService } from '../demo-storage'
+
+const storage = new DemoStorageService(objectStorage)
+await prepareDemoForGrading(demoHash, '/tmp/grading/demo', storage)
+```
+
+## Environment Variables
+
+The service respects the following environment variables:
+
+- `CQA_PATH`: Explicit path to CQA binary or source file (optional, auto-detected if not set)
+- `CQA_MODEL`: Model to use for grading (e.g., 'gemini-2.0-flash', 'gpt-4o')
+- `USE_VIDEO_GRADING`: Enable/disable video-based grading (default: true)
+- `OPENAI_API_KEY`: OpenAI API key for GPT models
+- `GEMINI_API_KEY`: Google Gemini API key
+- `ANTHROPIC_API_KEY`: Anthropic API key for Claude models
+
+## CQA Path Detection
+
+The service automatically detects the CQA path in the following order:
+
+1. **Explicit override**: `process.env.CQA_PATH` if set
+2. **Local development**: `../clones-quality-agent/src/index.ts` (runs with bun)
+3. **Docker/production**: `/app/clones-quality-agent` (compiled binary)
+
+This allows the same code to work seamlessly across:
+- Local macOS development (using bun + TypeScript source)
+- Docker development (using compiled binary)
+- Production deployment (using compiled binary)
+
+## Integration
+
+This service is used by:
+
+- **Upload processing** (`src/services/forge/processing.ts`): Grades demonstrations on upload
+- **Migration scripts** (`scripts/migrate-grade-demos.ts`): Grades legacy demonstrations
+- Any other service that needs to grade demonstrations
+
+## Benefits
+
+✅ **DRY**: Single source of truth for CQA grading logic  
+✅ **Maintainable**: Changes to grading logic only need to be made once  
+✅ **Consistent**: Same behavior across all use cases  
+✅ **Testable**: Easy to test and mock  
+✅ **Flexible**: Supports different environments and configurations
+

--- a/src/services/grading/cqaGradingService.ts
+++ b/src/services/grading/cqaGradingService.ts
@@ -1,0 +1,274 @@
+import { spawn } from 'node:child_process'
+import { promises as fs } from 'node:fs'
+import * as path from 'node:path'
+import { logger } from '../logger.ts'
+import type { ForgeSubmissionGradeResult } from '../../types/index.ts'
+
+export interface GradingOptions {
+    useVideoGrading?: boolean
+    model?: string
+    cleanupOnSuccess?: boolean
+    cleanupOnError?: boolean
+}
+
+export interface GradingResult {
+    gradeResult: ForgeSubmissionGradeResult
+    gradingMetrics: any | null
+}
+
+/**
+ * Get the CQA path based on environment
+ * Priority:
+ * 1. CQA_PATH environment variable (explicit override)
+ * 2. Local development path (../clones-quality-agent/src/index.ts)
+ * 3. Docker/production path (/app/clones-quality-agent)
+ */
+function getCQAPath(): { path: string; useBun: boolean } {
+    if (process.env.CQA_PATH) {
+        return {
+            path: process.env.CQA_PATH,
+            useBun: process.env.CQA_PATH.endsWith('.ts')
+        }
+    }
+
+    // Check for local development CQA using fs from node:fs (synchronous)
+    const localCQAPath = path.join(process.cwd(), '..', 'clones-quality-agent', 'src', 'index.ts')
+    try {
+        // Use fs.statSync which is more reliable than existsSync
+        const fsSync = require('node:fs')
+        fsSync.statSync(localCQAPath)
+        logger.info({ cqaPath: localCQAPath }, 'Using local CQA with bun')
+        return { path: localCQAPath, useBun: true }
+    } catch (error) {
+        // File doesn't exist or can't be accessed, fall back to Docker path
+    }
+
+    // Docker/production path
+    logger.info('Using Docker CQA path: /app/clones-quality-agent')
+    return { path: '/app/clones-quality-agent', useBun: false }
+}
+
+/**
+ * Run CQA grading on a directory containing demonstration files
+ * 
+ * @param inputDir - Directory containing recording.mp4, meta.json, input_log.jsonl, sft.json
+ * @param options - Grading options
+ * @returns Grade result and metrics
+ */
+export async function runCQAGrading(
+    inputDir: string,
+    options: GradingOptions = {}
+): Promise<GradingResult> {
+    const {
+        useVideoGrading = process.env.USE_VIDEO_GRADING !== 'false',
+        model = process.env.CQA_MODEL,
+        cleanupOnSuccess = false,
+        cleanupOnError = false
+    } = options
+
+    logger.info('Running CQA grading', { inputDir, useVideoGrading, model })
+
+    // Verify directory exists and has required files
+    try {
+        const files = await fs.readdir(inputDir)
+        logger.info('Directory contents', { files })
+
+        if (files.length === 0) {
+            throw new Error('No files found in input directory')
+        }
+    } catch (error) {
+        throw new Error(`Failed to read input directory: ${(error as Error).message}`)
+    }
+
+    const { path: cqaPath, useBun } = getCQAPath()
+
+    return new Promise((resolve, reject) => {
+        const absoluteInputDir = path.resolve(inputDir)
+
+        // Prepare CQA arguments
+        const cqaArgs = ['-f', 'desktop', '-i', absoluteInputDir, '--grade']
+
+        if (useVideoGrading) {
+            cqaArgs.push('--video-mode')
+            logger.info('Video grading mode enabled')
+        }
+
+        if (model) {
+            cqaArgs.push('--model', model)
+        }
+
+        // Determine command and args based on whether we're using bun or compiled binary
+        let command: string
+        let args: string[]
+        let cwd: string | undefined
+
+        if (useBun) {
+            // Use bun to run TypeScript source directly
+            command = 'bun'
+            args = ['run', cqaPath, ...cqaArgs]
+            cwd = path.dirname(cqaPath)
+            logger.info(`Executing CQA with bun: ${command} ${args.join(' ')}`, { cwd })
+        } else {
+            // Use compiled binary
+            command = cqaPath
+            args = cqaArgs
+            // Only use /app/cqa as cwd if it exists (Docker environment)
+            // Otherwise run from current directory
+            try {
+                require('node:fs').statSync('/app/cqa')
+                cwd = '/app/cqa'
+            } catch {
+                cwd = undefined
+            }
+            logger.info(`Executing CQA binary: ${command} ${args.join(' ')}`, { cwd: cwd || 'current directory' })
+        }
+
+        const cqaProcess = spawn(command, args, {
+            cwd,
+            env: {
+                ...process.env,
+                OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+                GEMINI_API_KEY: process.env.GEMINI_API_KEY,
+                ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY
+            }
+        })
+
+        let stdout = ''
+        let stderr = ''
+        let stdoutLineBuffer = ''
+        let stderrLineBuffer = ''
+
+        cqaProcess.stdout.on('data', (data) => {
+            stdout += data
+            stdoutLineBuffer += data.toString()
+
+            // Log complete lines as they come
+            const lines = stdoutLineBuffer.split('\n')
+            stdoutLineBuffer = lines.pop() || ''
+
+            lines.forEach((line) => {
+                if (line.trim()) {
+                    logger.info({ cqaOutput: 'stdout', line }, 'CQA stdout')
+                }
+            })
+        })
+
+        cqaProcess.stderr.on('data', (data) => {
+            stderr += data
+            stderrLineBuffer += data.toString()
+
+            // Log complete lines as they come
+            const lines = stderrLineBuffer.split('\n')
+            stderrLineBuffer = lines.pop() || ''
+
+            lines.forEach((line) => {
+                if (line.trim()) {
+                    logger.warn({ cqaOutput: 'stderr', line }, 'CQA stderr')
+                }
+            })
+        })
+
+        cqaProcess.on('close', async (code: number) => {
+            // Log any remaining buffer content
+            if (stdoutLineBuffer.trim()) {
+                logger.info({ cqaOutput: 'stdout', line: stdoutLineBuffer.trim() }, 'CQA stdout (final)')
+            }
+            if (stderrLineBuffer.trim()) {
+                logger.warn({ cqaOutput: 'stderr', line: stderrLineBuffer.trim() }, 'CQA stderr (final)')
+            }
+
+            if (code === 0) {
+                logger.info({ exitCode: code }, 'CQA grading completed successfully')
+
+                try {
+                    // Read scores.json
+                    const scoresPath = path.join(inputDir, 'scores.json')
+                    await fs.access(scoresPath)
+                    const scoresContent = await fs.readFile(scoresPath, 'utf8')
+                    const gradeResult: ForgeSubmissionGradeResult = JSON.parse(scoresContent)
+                    logger.info('Grade result', { score: gradeResult.score })
+
+                    // Read metrics.json if available
+                    let gradingMetrics = null
+                    const metricsPath = path.join(inputDir, 'metrics.json')
+                    try {
+                        await fs.access(metricsPath)
+                        const metricsContent = await fs.readFile(metricsPath, 'utf8')
+                        gradingMetrics = JSON.parse(metricsContent)
+                        logger.info('Grading metrics available')
+                    } catch {
+                        logger.info('No metrics.json found')
+                    }
+
+                    // Cleanup on success if requested
+                    if (cleanupOnSuccess) {
+                        try {
+                            await fs.rm(inputDir, { recursive: true, force: true })
+                            logger.info('Cleaned up temp directory after success', { inputDir })
+                        } catch (cleanupError) {
+                            logger.warn('Failed to cleanup temp directory', { error: cleanupError })
+                        }
+                    }
+
+                    resolve({ gradeResult, gradingMetrics })
+                } catch (error) {
+                    reject(new Error(`Failed to read grading results: ${(error as Error).message}`))
+                }
+            } else {
+                logger.error({
+                    exitCode: code,
+                    fullStdout: stdout,
+                    fullStderr: stderr
+                }, 'CQA grading failed')
+
+                // Cleanup on error if requested
+                if (cleanupOnError) {
+                    try {
+                        await fs.rm(inputDir, { recursive: true, force: true })
+                        logger.info('Cleaned up temp directory after error', { inputDir })
+                    } catch (cleanupError) {
+                        logger.warn('Failed to cleanup temp directory', { error: cleanupError })
+                    }
+                }
+
+                reject(new Error(`CQA grading failed with code ${code}\nstdout: ${stdout}\nstderr: ${stderr}`))
+            }
+        })
+
+        cqaProcess.on('error', (err) => {
+            logger.error('CQA spawn error', { error: err })
+            reject(new Error(`Failed to start CQA: ${err.message}`))
+        })
+    })
+}
+
+/**
+ * Prepare a directory for grading by downloading demo files
+ * This is a utility function for use with runCQAGrading
+ */
+export async function prepareDemoForGrading(
+    demoHash: string,
+    targetDir: string,
+    storageService: any
+): Promise<void> {
+    logger.info('Preparing demo for grading', { demoHash, targetDir })
+
+    // Create target directory
+    await fs.mkdir(targetDir, { recursive: true })
+
+    const requiredFiles = ['recording.mp4', 'meta.json', 'input_log.jsonl', 'sft.json']
+
+    for (const filename of requiredFiles) {
+        try {
+            const fileBuffer = await storageService.getDemoFile(demoHash, filename)
+            const filePath = path.join(targetDir, filename)
+            await fs.writeFile(filePath, fileBuffer)
+            logger.info(`Downloaded ${filename}`, { size: fileBuffer.length })
+        } catch (error) {
+            throw new Error(`Failed to download ${filename}: ${(error as Error).message}`)
+        }
+    }
+
+    logger.info('Demo files prepared for grading')
+}
+

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -131,7 +131,7 @@ function createRedactConfig() {
 function getBaseLabels() {
   return {
     service: process.env.SERVICE_NAME || 'clones-backend',
-    environment: process.env.NODE_ENV || 'development', 
+    environment: process.env.NODE_ENV || 'development',
     version: process.env.npm_package_version || '1.0.0',
     instance: process.env.FLY_ALLOC_ID || process.env.HOSTNAME || 'local'
   }
@@ -225,7 +225,7 @@ function createTransport() {
       colorize: true,
       translateTime: 'HH:mm:ss Z',
       // Hide technical metadata in dev for cleaner output
-      ignore: 'pid,hostname,service,version,environment,instance,correlationId,requestId,traceId,spanId,cqaOutput,exitcode'
+      ignore: 'pid,hostname,service,version,environment,instance,correlationId,requestId,traceId,spanId,cqaOutput,exitCode'
     }
   }
 }
@@ -327,12 +327,12 @@ export class ContextLogger {
       // Create a more descriptive message based on the object type and context
       const context = getCurrentLogContext()
       const objectType = objOrMsg?.constructor?.name || typeof objOrMsg
-      const scope = context.requestId && context.requestId.length >= 8 ? `[req:${context.requestId.slice(-8)}]` : 
-                   context.requestId ? `[req:${context.requestId}]` :
-                   context.correlationId && context.correlationId.length >= 8 ? `[corr:${context.correlationId.slice(-8)}]` : 
-                   context.correlationId ? `[corr:${context.correlationId}]` :
-                   '[no-context]'
-      
+      const scope = context.requestId && context.requestId.length >= 8 ? `[req:${context.requestId.slice(-8)}]` :
+        context.requestId ? `[req:${context.requestId}]` :
+          context.correlationId && context.correlationId.length >= 8 ? `[corr:${context.correlationId.slice(-8)}]` :
+            context.correlationId ? `[corr:${context.correlationId}]` :
+              '[no-context]'
+
       const message = `${scope} Logged ${objectType} without explicit message`
       this.pino[level]({ data: objOrMsg }, message)
     } else {

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -218,13 +218,14 @@ function createTransport() {
     return undefined // Let Pino default to stdout
   }
 
-  // Development: Pretty print
+  // Development: Pretty print with minimal noise
   return {
     target: 'pino-pretty',
     options: {
       colorize: true,
       translateTime: 'HH:mm:ss Z',
-      ignore: 'pid,hostname,service,version,environment,instance'
+      // Hide technical metadata in dev for cleaner output
+      ignore: 'pid,hostname,service,version,environment,instance,correlationId,requestId,traceId,spanId,cqaOutput,exitcode'
     }
   }
 }

--- a/src/services/storage/index.ts
+++ b/src/services/storage/index.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from 'node:fs'
-import { PutObjectCommand, S3Client, GetObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
+import { PutObjectCommand, S3Client, GetObjectCommand, DeleteObjectCommand, HeadObjectCommand } from '@aws-sdk/client-s3'
 
 export class ObjectStorageService {
   private client: S3Client
@@ -90,6 +90,50 @@ export class ObjectStorageService {
     return response.Body as NodeJS.ReadableStream
   }
 
+  async getItemStreamWithRange(options: {
+    name: string
+    bucket?: string
+    range?: string // HTTP Range header value (e.g., "bytes=0-1023")
+  }): Promise<{
+    stream: NodeJS.ReadableStream
+    contentLength: number
+    contentRange?: string
+    totalSize: number
+  }> {
+    const command = new GetObjectCommand({
+      Bucket: options.bucket || this.bucket,
+      Key: options.name,
+      Range: options.range
+    })
+
+    const response = await this.client.send(command)
+
+    if (!response.Body) {
+      throw new Error(`Object not found: ${options.name}`)
+    }
+
+    // For range requests, S3 returns ContentRange header
+    // Format: "bytes start-end/total"
+    const contentRange = response.ContentRange
+    const contentLength = response.ContentLength || 0
+
+    // Extract total size from ContentRange or use ContentLength for full requests
+    let totalSize = contentLength
+    if (contentRange) {
+      const match = contentRange.match(/bytes \d+-\d+\/(\d+)/)
+      if (match) {
+        totalSize = parseInt(match[1], 10)
+      }
+    }
+
+    return {
+      stream: response.Body as NodeJS.ReadableStream,
+      contentLength,
+      contentRange,
+      totalSize
+    }
+  }
+
   async deleteItem(options: { name: string; bucket?: string }): Promise<void> {
     const command = new DeleteObjectCommand({
       Bucket: options.bucket || this.bucket,
@@ -97,5 +141,26 @@ export class ObjectStorageService {
     })
 
     await this.client.send(command)
+  }
+
+  async checkFileExists(options: { name: string; bucket?: string }): Promise<{ exists: boolean; size?: number }> {
+    try {
+      const command = new HeadObjectCommand({
+        Bucket: options.bucket || this.bucket,
+        Key: options.name
+      })
+
+      const response = await this.client.send(command)
+
+      return {
+        exists: true,
+        size: response.ContentLength
+      }
+    } catch (error: any) {
+      if (error.name === 'NotFound' || error.$metadata?.httpStatusCode === 404) {
+        return { exists: false }
+      }
+      throw error
+    }
   }
 }

--- a/src/types/factory.ts
+++ b/src/types/factory.ts
@@ -59,8 +59,6 @@ export interface FactoryApp {
   tasks: FactoryTask[]
 }
 
-// NEW TASK-FIRST STRUCTURE
-
 // Simplified app definition for use within tasks
 export interface TaskApp {
   name: string
@@ -77,6 +75,7 @@ export interface WorkflowTask {
   apps_used: TaskApp[]
   uploadLimit?: number
   rewardLimit?: number
+  objectives?: string[]
 }
 
 // Main Factory interface - canonical structure
@@ -115,11 +114,23 @@ export interface Factory {
   searchText?: string // Computed search string
 }
 
-export interface FactoryWithDemonstrations extends Factory {
-  demonstrations: number
+// Grading result summary for a single submission
+export interface GradingResultSummary {
+  submissionId: string
+  createdAt: Date
+  score: number
+  confidence?: number
+  outcomeAchievement?: number
+  processQuality?: number
+  efficiency?: number
 }
 
-// NEW: Workflow generation response from AI
+export interface FactoryWithDemonstrations extends Factory {
+  demonstrations: number
+  balance?: number // Optional pool balance (in tokens)
+  gradingResults?: GradingResultSummary[] // Optional grading results for completed demonstrations
+}
+
 export interface WorkflowGenerationResult {
   name: string
   tasks: Omit<WorkflowTask, 'id'>[] // Tasks without IDs (will be generated)
@@ -135,9 +146,6 @@ export interface CreateFactoryRequest {
     symbol: string
   }
   uploadLimit?: FactoryUploadLimit
-  // Legacy support
-  apps?: Omit<FactoryApp, 'id'>[] // Apps without IDs (will be generated)
-  // NEW: Tasks-first support
   tasks?: Omit<WorkflowTask, 'id'>[] // Tasks without IDs (will be generated)
 }
 
@@ -149,9 +157,6 @@ export interface UpdateFactoryRequest {
   skills?: string[]
   status?: FactoryStatus
   uploadLimit?: FactoryUploadLimit
-  // Legacy support
-  apps?: Omit<FactoryApp, 'id'>[]
-  // NEW: Tasks-first support
   tasks?: Omit<WorkflowTask, 'id'>[]
 }
 


### PR DESCRIPTION
This pull request introduces several new migration and cleanup scripts to support data migration and maintenance, updates the CQA package version in Docker-related files, and adds support for the `objectives` field in task-related API endpoints. The changes are primarily focused on backend data management and API enhancements.

**Migration and Cleanup Scripts:**

* Added a script to import legacy viralmind data into the new factory structure, transforming and inserting data into the database while handling duplicates and errors (`scripts/viralmind-migration/migrate-viralmind-data.ts`).
* Introduced a migration script to grade legacy demonstration submissions using the backend API, with support for environment selection and submission limits (`scripts/viralmind-migration/migrate-grade-demos.ts`).
* Added a cleanup script to remove old `sft.json` files from directories older than 5 minutes in `data/sft_files`, helping manage disk space (`scripts/viralmind-migration/cleanup-old-sft-files.ts`).

**API Enhancements:**

* Extended task-related endpoints in `src/api/forge/apps.ts` to include the `objectives` field in aggregation pipelines and responses, allowing clients to access task objectives. [[1]](diffhunk://#diff-510029248e008a2573a9a8ca68343a8f12292883122d1937c8d9e3c14eb34935R126) [[2]](diffhunk://#diff-510029248e008a2573a9a8ca68343a8f12292883122d1937c8d9e3c14eb34935R473) [[3]](diffhunk://#diff-510029248e008a2573a9a8ca68343a8f12292883122d1937c8d9e3c14eb34935L556-R559)

**Docker Configuration Updates:**

* Updated the CQA package version from `3.0.4` to `3.0.12` in both `Dockerfile` and `Dockerfile.dev` to ensure the latest quality agent is used. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L36-R36) [[2]](diffhunk://#diff-86930c95a19b82f7e64a962a0053d44e855824813019b3698eae4917a90cdcacL7-R7)
* Removed the `deb.debian.org:host-gateway` entry from the `extra_hosts` section in `docker-compose.yml`, likely as a cleanup or because it is no longer needed.

**Miscellaneous:**

* Minor import update in `src/api/forge/chat.ts` to include `ApiError` from error types.